### PR TITLE
allow kinesis to be used directly for debugging [Delivers #Cx4kjymY]

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -19,6 +19,7 @@ require "streamy/simple_logger"
 require "streamy/message_buses/test_message_bus"
 require "streamy/message_buses/file_message_bus"
 require "streamy/message_buses/fluent_message_bus"
+require "streamy/message_buses/kinesis_message_bus"
 
 # Event stores
 require "streamy/event_stores/copy_buffered_redshift_store"

--- a/lib/streamy/message_buses/kinesis_message_bus.rb
+++ b/lib/streamy/message_buses/kinesis_message_bus.rb
@@ -1,0 +1,43 @@
+require "multi_json"
+
+module Streamy
+  module MessageBuses
+    class KinesisMessageBus
+      def initialize(stream)
+        @stream = stream
+      end
+
+      def deliver(key:, topic:, type:, body:, event_time:)
+        client.put_record(
+          stream_name: stream,
+          partition_key: partition_key,
+          data: MultiJson.dump(
+            key: key,
+            topic: topic,
+            type: type,
+            body: body,
+            event_time: event_time
+          )
+        )
+      end
+
+      private
+
+        attr_reader :stream
+
+        def client
+          @_client ||= Aws::Kinesis::Client.new(config)
+        end
+
+        def config
+          {
+            region: "us-east-1"
+          }
+        end
+
+        def partition_key
+          "snsr-#{rand(1_000).to_s.rjust(4,'0')}" # not sure what is up with this https://github.com/awslabs/amazon-kinesis-client-ruby/blob/master/samples/sample_kcl_producer.rb#L80
+        end
+    end
+  end
+end


### PR DESCRIPTION
#Just the basics with hardcoded defaults and a partition_key I'm not fully understanding yet 😅 

Need to add something like:

```ruby
Streamy.message_bus = Streamy::MessageBuses::KinesisMessageBus.new("STREAM NAME")
```

to run it.