### PR TITLE
Delete duplicated dependency

### DIFF
--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 4.0.0"
   spec.add_dependency "aws-kclrb"
   spec.add_dependency "aws-sdk", "~> 2"
-  spec.add_dependency "aws-kclrb"
   spec.add_dependency "fluent-logger"
   spec.add_dependency "redshift-connector"
   spec.add_dependency "webmock"


### PR DESCRIPTION
It looks like you both tried to fix the same issue and when the commits were merged the dependency was duplicated.

(Now I understand better why having the gems sorted alphabetically in the Gemfile is a "best practice") 🤔 