### PR TITLE
fluent_message_bus: Reuse FluentLogger

### DIFF
--- a/lib/streamy/message_buses/fluent_message_bus.rb
+++ b/lib/streamy/message_buses/fluent_message_bus.rb
@@ -21,7 +21,7 @@ module Streamy
         attr_reader :tag_prefix
 
         def client
-          Fluent::Logger::FluentLogger.new(tag_prefix)
+          @client ||= Fluent::Logger::FluentLogger.new(tag_prefix)
         end
     end
   end


### PR DESCRIPTION
FluentLogger has queue, buffer and socket pool internally, so basically
we shouldn't instantiate it every time we need. Otherwise it may leads
a process to have too many opened sockets.

Merging this without waiting for a review because the changed lines are suspicious of Errno::EMFILE in our production system.

FYI @balvig 