### PR TITLE
Allow importer to take a file name

### DIFF
--- a/lib/streamy/event_stores/copy_buffered_redshift_store.rb
+++ b/lib/streamy/event_stores/copy_buffered_redshift_store.rb
@@ -17,8 +17,8 @@ module Streamy
         data_source
       end
 
-      def import(&block)
-        importer.import(&block)
+      def import(file_name, &block)
+        build_importer(file_name: file_name).import(&block)
       end
 
       private
@@ -40,8 +40,9 @@ module Streamy
           RedshiftConnector::S3Bucket.add reader_config[:bucket], reader_config
         end
 
-        def importer
-          Redshift::Importer.new(importer_config)
+        def build_importer(file_name:)
+          options = importer_config.merge(file_name: file_name)
+          Redshift::Importer.new(options)
         end
 
         def reader_config
@@ -56,7 +57,6 @@ module Streamy
         def importer_config
           {
             folder: s3[:write_folder],
-            iam_role: s3[:iam_role],
             region: s3[:region],
             bucket: s3[:bucket]
           }

--- a/lib/streamy/event_stores/redshift/importer.rb
+++ b/lib/streamy/event_stores/redshift/importer.rb
@@ -7,6 +7,7 @@ module Streamy
         end
 
         def import
+          remove_file
           pipe_messages_to_file
           yield
           gzip_file
@@ -31,7 +32,7 @@ module Streamy
           end
 
           def remove_file
-            FileUtils.rm(gzip_file_path)
+            FileUtils.rm_f(gzip_file_path)
           end
 
           def file_path

--- a/lib/streamy/message_buses/fluent_message_bus.rb
+++ b/lib/streamy/message_buses/fluent_message_bus.rb
@@ -21,7 +21,7 @@ module Streamy
         attr_reader :tag_prefix
 
         def client
-          @client ||= Fluent::Logger::FluentLogger.new(tag_prefix)
+          @_client ||= Fluent::Logger::FluentLogger.new(tag_prefix)
         end
     end
   end


### PR DESCRIPTION
Need this so that we can split the imports into smaller chunks:

![1__tmux](https://cloud.githubusercontent.com/assets/104138/26193142/3f721ee4-3bef-11e7-9b83-dfb25804c693.png)

Going to move ahead with this in spike mode, as I think maybe we can remove the need for all this redshift/S3 interaction if we create a consumer to handle saving the events.