### PR TITLE
Fix broken gemspec

### DIFF
--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Basic toolset for hooking into event stream}
   spec.description   = %q{Basic toolset for hooking into event stream}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/cookpad/streamy"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
It seems like newer version of RubyGems or Bundler now require a gemspec
to have a valid HTTP URI in its `homepage` value, as I got this error:

    The gemspec at [..] is not valid. Please fix this gemspec.  The
    validation error was '"TODO: Put your gem's website or public repo
    URL here." is not a valid HTTP URI'