### PR TITLE
Move the hutch connection out of message bus initializer

### DIFF
--- a/lib/streamy/message_buses/rabbit_message_bus.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus.rb
@@ -7,7 +7,6 @@ module Streamy
         @topic_prefix = topic_prefix
         Hutch::Config.set(:uri, uri)
         Hutch::Config.set(:enable_http_api_use, false)
-        Hutch.connect
       end
 
       def deliver(*args)
@@ -15,6 +14,7 @@ module Streamy
       end
 
       def deliver_now(key:, topic:, type:, body:, event_time:)
+        Hutch.connect
         Hutch.publish(
           "#{topic_prefix}.#{topic}.#{type}",
           topic: topic,


### PR DESCRIPTION
So that when we load the rails app, e.g. console or tests, it won't try to connect to Hutch.

`Hutch.connect` could be ran multiple times, it will only [establish the connection once](https://github.com/gocardless/hutch/blob/601f1882a61c1e384fa750c418275a902659ece7/lib/hutch.rb#L46). 