### PR TITLE
Configure rabbitmq URI in secrets.yml

### DIFF
--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -1,8 +1,18 @@
 namespace :streamy do
   namespace :consumer do
     desc "Start consuming"
-    task :run do
-      system "bundle exec hutch --config config/rabbit_mq.yml"
+    task run: :environment do
+      if Rails.application.secrets.rabbitmq_uri.blank?
+        raise "Missing `rabbitmq_uri` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
+      end
+
+      system(
+        {
+          "HUTCH_URI" => Rails.application.secrets.rabbitmq_uri,
+          "HUTCH_ENABLE_HTTP_API_USE" => "false"
+        },
+        "bundle exec hutch"
+      )
     end
   end
 end


### PR DESCRIPTION
Instead of depending on an external `config/rabbitmq.yml` configuration file, now the consumer task will expect the rabbitmq uri to be defined in `secrets.yml`. This makes easy to have different URIs by environment 