### PR TITLE
raise a streamy error when rabbit fails to connect

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -15,11 +15,13 @@ module Streamy
 
   # Errors
   require "streamy/errors/event_handler_not_found_error"
+  require "streamy/errors/publication_failed_error"
   require "streamy/errors/type_not_found_error"
 
   # Message Buses
   require "streamy/message_buses/test_message_bus"
   require "streamy/message_buses/rabbit_message_bus"
+  require "streamy/message_buses/rabbit_message_bus/message"
 
   # Rake task
   require "streamy/railtie" if defined?(Rails)

--- a/lib/streamy/errors/publication_failed_error.rb
+++ b/lib/streamy/errors/publication_failed_error.rb
@@ -1,0 +1,10 @@
+module Streamy
+  class PublicationFailedError < StandardError
+    attr_reader :event_params
+
+    def initialize(original_error, **event_params)
+      @event_params = event_params
+      super "Failed publishing event: #{event_params} \n#{original_error.class} - #{original_error.message}"
+    end
+  end
+end

--- a/lib/streamy/message_buses/rabbit_message_bus.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus.rb
@@ -3,8 +3,7 @@ require "hutch"
 module Streamy
   module MessageBuses
     class RabbitMessageBus
-      def initialize(uri:, topic_prefix: Streamy::DEFAULT_TOPIC_PREFIX)
-        @topic_prefix = topic_prefix
+      def initialize(uri:)
         Hutch::Config.set(:uri, uri)
         Hutch::Config.set(:enable_http_api_use, false)
       end
@@ -14,20 +13,14 @@ module Streamy
       end
 
       def deliver_now(key:, topic:, type:, body:, event_time:)
-        Hutch.connect
-        Hutch.publish(
-          "#{topic_prefix}.#{topic}.#{type}",
-          topic: topic,
+        Message.new(
           key: key,
-          body: body,
+          topic: topic,
           type: type,
+          body: body,
           event_time: event_time
-        )
+        ).publish
       end
-
-      private
-
-        attr_reader :topic_prefix
     end
   end
 end

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -1,0 +1,34 @@
+require "hutch"
+
+module Streamy
+  module MessageBuses
+    class RabbitMessageBus::Message
+      def initialize(**params)
+        @params = params
+      end
+
+      def publish
+        Hutch.connect
+        Hutch.publish(routing_key, params)
+      rescue => e
+        raise PublicationFailedError.new(e, params)
+      end
+
+      private
+
+        attr_reader :params
+
+        def routing_key
+          "#{Streamy::DEFAULT_TOPIC_PREFIX}.#{topic}.#{type}"
+        end
+
+        def topic
+          params[:topic]
+        end
+
+        def type
+          params[:type]
+        end
+    end
+  end
+end

--- a/test/rabbit_message_bus_test.rb
+++ b/test/rabbit_message_bus_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+module Streamy
+  class RabbitMessageBusTest < Minitest::Test
+    def setup
+      Hutch::Logging.logger = stub(info: true, error: true)
+    end
+
+    def test_deliver
+      bus = MessageBuses::RabbitMessageBus.new(uri: "valid_uri")
+
+      Hutch.expects(:connect)
+      Hutch.expects(:publish).with("global.topic.type", key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
+
+      bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
+    end
+
+    def test_connection_error
+      bus = MessageBuses::RabbitMessageBus.new(uri: "broken_uri")
+
+      error = assert_raises(PublicationFailedError) do
+        bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: Time.now)
+      end
+
+      assert_match(/ConnectionError/, error.message)
+    end
+  end
+end


### PR DESCRIPTION
For now we want to leave it up to each publisher how to react if the app should fail to connect to the RabbitMQ broker.

We do this by raising a custom `Streamy::PublicationFailedError` that can then be rescued in the app publishing the event, for example:

```ruby
module Events
  class ApplicationEvent < Streamy::Event
    def publish
      super
    rescue Streamy::PublicationFailedError => e
      # Rails.logger("Failed publishing: #{e.event_params})
      # FailedEvent.create(e.event_params)
      # raise
      # etc
    end
  end
end
```

We aren't completely sure what the best way of handling this (rare) occurrence is with regards to ordering etc, but since `global-reports` doesn't care about the order of events, for now logging might be enough as we continue to get a better understanding of what the best practices are!