### PR TITLE
[Bristol Camp] Configure :error_acknodlegments  in the rake task

### DIFF
--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -5,22 +5,10 @@ module Streamy
     def self.included(base)
       base.include Hutch::Consumer
       base.consume "#{Streamy::DEFAULT_TOPIC_PREFIX}.#"
-
-      configure_hutch
     end
 
     def process(message)
       MessageProcessor.new(message).run
-    end
-
-    def self.configure_hutch
-      Hutch::Config.set(
-        :error_acknowledgements,
-        [
-          RabbitMq::Acknowledgements::RequeueOnAllFailures.new,
-          RabbitMq::Acknowledgements::AbortOnAllFailures.new
-        ]
-      )
     end
   end
 end

--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -1,7 +1,7 @@
 namespace :streamy do
   namespace :consumer do
     desc "Start consuming"
-    task run: :environment do
+    task :run do
       if Rails.application.secrets.rabbitmq_uri.blank?
         raise "Missing `rabbitmq_uri` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
       end

--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -6,13 +6,11 @@ namespace :streamy do
         raise "Missing `rabbitmq_uri` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
       end
 
-      system(
-        {
-          "HUTCH_URI" => Rails.application.secrets.rabbitmq_uri,
-          "HUTCH_ENABLE_HTTP_API_USE" => "false"
-        },
-        "bundle exec hutch"
-      )
+      Hutch::Config[:uri] = Rails.application.secrets.rabbitmq_uri
+      Hutch::Config[:enable_http_api_use] = false
+
+      cli = Hutch::CLI.new
+      cli.run(ARGV)
     end
   end
 end

--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -12,7 +12,7 @@ namespace :streamy do
       Hutch::Config[:error_acknowledgements] << Streamy::RabbitMq::Acknowledgements::AbortOnAllFailures.new
 
       cli = Hutch::CLI.new
-      cli.run(ARGV)
+      cli.run([])
     end
   end
 end

--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -8,6 +8,8 @@ namespace :streamy do
 
       Hutch::Config[:uri] = Rails.application.secrets.rabbitmq_uri
       Hutch::Config[:enable_http_api_use] = false
+      Hutch::Config[:error_acknowledgements] << Streamy::RabbitMq::Acknowledgements::RequeueOnAllFailures.new
+      Hutch::Config[:error_acknowledgements] << Streamy::RabbitMq::Acknowledgements::AbortOnAllFailures.new
 
       cli = Hutch::CLI.new
       cli.run(ARGV)


### PR DESCRIPTION
We want to add some custom classes for error acknowledgment. In order to do that we directly call Hutch::CLI class instead of spawning a new process. Before that, we configure Hutch properly.