### PR TITLE
Prevent duplicated events

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -4,6 +4,7 @@ module Streamy
   # External
   # TODO: Move into classes that use them
   require "active_support"
+  require "active_support/core_ext/string"
 
   require "streamy/version"
   require "streamy/consumer"

--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -32,7 +32,7 @@ module Streamy
   require "streamy/railtie" if defined?(Rails)
 
   class << self
-    attr_accessor :message_bus, :logger
+    attr_accessor :message_bus, :logger, :cache
   end
 
   self.logger = SimpleLogger.new

--- a/lib/streamy/message_processor.rb
+++ b/lib/streamy/message_processor.rb
@@ -5,12 +5,30 @@ module Streamy
     end
 
     def run
-      event_handler.new(attributes).process
+      ignoring_duplicates do
+        event_handler.new(attributes).process
+      end
     end
 
     private
 
       attr_reader :message
+
+      def ignoring_duplicates(&block)
+        return yield if cache.nil?
+
+        cache.fetch("streamy/events/#{key}") do
+          yield
+        end
+      end
+
+      def cache
+        Streamy.cache
+      end
+
+      def key
+        message[:key]
+      end
 
       def event_handler
         handler_class_name.safe_constantize || raise(handler_not_found_error)

--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "active_support/cache/memory_store"
 
 class DummyConsumer
   include Streamy::Consumer
@@ -6,9 +7,7 @@ end
 
 module EventHandlers
   class DummyEvent < Streamy::EventHandler
-    cattr_accessor :times_called do
-      0
-    end
+    cattr_accessor :times_called
 
     def process
       self.times_called += 1
@@ -18,20 +17,36 @@ end
 
 module Streamy
   class ConsumerTest < Minitest::Test
+    def setup
+      EventHandlers::DummyEvent.times_called = 0
+    end
+
     def test_processing_empty_message
       message = {}
+
       assert_raises(TypeNotFoundError) do
         DummyConsumer.new.process(message)
       end
     end
 
-    def test_ignoring_duplicate_messages
+    def test_ignoring_duplicate_messages_if_cache_is_on
+      Streamy.cache = ActiveSupport::Cache::MemoryStore.new
       message = { key: "1234", type: "dummy_event" }
 
       DummyConsumer.new.process(message)
       DummyConsumer.new.process(message)
 
       assert_equal 1, EventHandlers::DummyEvent.times_called
+    end
+
+    def test_allowing_duplicate_messages_if_cache_is_off
+      Streamy.cache = nil
+      message = { key: "1234", type: "dummy_event" }
+
+      DummyConsumer.new.process(message)
+      DummyConsumer.new.process(message)
+
+      assert_equal 2, EventHandlers::DummyEvent.times_called
     end
   end
 end

--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -1,16 +1,37 @@
 require "test_helper"
 
-module Streamy
-  class ConsumerTest < Minitest::Test
-    class DummyConsumer
-      include Consumer
+class DummyConsumer
+  include Streamy::Consumer
+end
+
+module EventHandlers
+  class DummyEvent < Streamy::EventHandler
+    cattr_accessor :times_called do
+      0
     end
 
+    def process
+      self.times_called += 1
+    end
+  end
+end
+
+module Streamy
+  class ConsumerTest < Minitest::Test
     def test_processing_empty_message
       message = {}
       assert_raises(TypeNotFoundError) do
         DummyConsumer.new.process(message)
       end
+    end
+
+    def test_ignoring_duplicate_messages
+      message = { key: "1234", type: "dummy_event" }
+
+      DummyConsumer.new.process(message)
+      DummyConsumer.new.process(message)
+
+      assert_equal 1, EventHandlers::DummyEvent.times_called
     end
   end
 end


### PR DESCRIPTION
Allows consumers to set

```ruby
Streamy.cache = # Rails.cache, MemoryStore.new etc
```

in order to deduplicate events.