### PR TITLE
refactor to help testing in other apps

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -20,6 +20,7 @@ module Streamy
   require "streamy/errors/type_not_found_error"
 
   # Message Buses
+  require "streamy/message_buses/message_bus"
   require "streamy/message_buses/test_message_bus"
   require "streamy/message_buses/rabbit_message_bus"
   require "streamy/message_buses/rabbit_message_bus/message"

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -5,7 +5,7 @@ module Streamy
     end
 
     def publish
-      message_bus.deliver(
+      message_bus.safe_deliver(
         key: key,
         topic: topic,
         type: type,

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -1,0 +1,15 @@
+module Streamy
+  module MessageBuses
+    class MessageBus
+      def safe_deliver(*args)
+        deliver(*args)
+      rescue => e
+        raise PublicationFailedError.new(e, *args)
+      end
+
+      def deliver(key:, topic:, type:, body:, event_time:)
+        raise "not implemented"
+      end
+    end
+  end
+end

--- a/lib/streamy/message_buses/rabbit_message_bus.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus.rb
@@ -2,17 +2,13 @@ require "hutch"
 
 module Streamy
   module MessageBuses
-    class RabbitMessageBus
+    class RabbitMessageBus < MessageBus
       def initialize(uri:)
         Hutch::Config.set(:uri, uri)
         Hutch::Config.set(:enable_http_api_use, false)
       end
 
-      def deliver(*args)
-        deliver_now(*args)
-      end
-
-      def deliver_now(key:, topic:, type:, body:, event_time:)
+      def deliver(key:, topic:, type:, body:, event_time:)
         Message.new(
           key: key,
           topic: topic,

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -10,8 +10,6 @@ module Streamy
       def publish
         Hutch.connect
         Hutch.publish(routing_key, params)
-      rescue => e
-        raise PublicationFailedError.new(e, params)
       end
 
       private

--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -1,6 +1,6 @@
 module Streamy
   module MessageBuses
-    class TestMessageBus
+    class TestMessageBus < MessageBus
       cattr_accessor :deliveries do
         []
       end

--- a/test/message_bus_test.rb
+++ b/test/message_bus_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module Streamy
+  class MessageBusTest < Minitest::Test
+    class DummyMessageBus < MessageBuses::MessageBus
+      def deliver(key:, topic:, type:, body:, event_time:)
+        raise "ConnectionError"
+      end
+    end
+
+    def test_safe_deliver_wrapping_errors
+      bus = DummyMessageBus.new
+
+      error = assert_raises(PublicationFailedError) do
+        bus.safe_deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: Time.now)
+      end
+
+      assert_match(/ConnectionError/, error.message)
+    end
+  end
+end

--- a/test/rabbit_message_bus_test.rb
+++ b/test/rabbit_message_bus_test.rb
@@ -2,10 +2,6 @@ require "test_helper"
 
 module Streamy
   class RabbitMessageBusTest < Minitest::Test
-    def setup
-      Hutch::Logging.logger = stub(info: true, error: true)
-    end
-
     def test_deliver
       bus = MessageBuses::RabbitMessageBus.new(uri: "valid_uri")
 
@@ -13,16 +9,6 @@ module Streamy
       Hutch.expects(:publish).with("global.topic.type", key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
 
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
-    end
-
-    def test_connection_error
-      bus = MessageBuses::RabbitMessageBus.new(uri: "broken_uri")
-
-      error = assert_raises(PublicationFailedError) do
-        bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: Time.now)
-      end
-
-      assert_match(/ConnectionError/, error.message)
     end
   end
 end


### PR DESCRIPTION
- Have all message buses inherit from a base class to give the `Streamy::PublicationError` capability to _all_ buses, not just Rabiit
- Avoids having to actually try to connect to rabbitmq during the failure test
- Helps https://github.com/cookpad/global-web/pull/7211/commits/15f554c56444dc7755a4049cc5f0ac91b10452c3 in simulating a publication feature