### PR TITLE
provide more information when aborting consumer

### DIFF
--- a/lib/streamy/rabbit_mq/acknowledgements/abort_on_all_failures.rb
+++ b/lib/streamy/rabbit_mq/acknowledgements/abort_on_all_failures.rb
@@ -6,8 +6,9 @@ module Streamy
       class AbortOnAllFailures < Hutch::Acknowledgements::Base
         include Hutch::Logging
 
-        def handle(*)
-          logger.debug "[x] abort consumer"
+        def handle(delivery_info, properties, broker, ex)
+          logger.error ex
+          logger.error "[x] aborting consumer"
 
           exit
         end


### PR DESCRIPTION
```
2018-03-18T16:15:53Z 61387 INFO -- hutch booted with pid 61387
2018-03-18T16:15:53Z 61387 INFO -- found rails project (.), booting app in development environment
2018-03-18T16:15:53Z 61387 INFO -- connecting to rabbitmq (amqp://lgfviuok@sidewinder.rmq.cloudamqp.com:5672/lgfviuok)
2018-03-18T16:15:55Z 61387 INFO -- connected to RabbitMQ at sidewinder.rmq.cloudamqp.com as lgfviuok
2018-03-18T16:15:55Z 61387 INFO -- opening rabbitmq channel with pool size 1, abort on exception false
2018-03-18T16:15:56Z 61387 INFO -- using topic exchange 'hutch'
2018-03-18T16:15:56Z 61387 INFO -- HTTP API use is disabled
2018-03-18T16:15:56Z 61387 INFO -- tracing is disabled
2018-03-18T16:15:56Z 61387 INFO -- setting up queues
2018-03-18T16:15:56Z 61387 INFO -- setting up queue: global_reports_consumer
Documents/global-reports [master●] »
```

versus

```
2018-03-18T16:18:43Z 62162 INFO -- hutch booted with pid 62162
2018-03-18T16:18:43Z 62162 INFO -- found rails project (.), booting app in development environment
2018-03-18T16:18:43Z 62162 INFO -- connecting to rabbitmq (amqp://lgfviuok@sidewinder.rmq.cloudamqp.com:5672/lgfviuok)
2018-03-18T16:18:47Z 62162 INFO -- connected to RabbitMQ at sidewinder.rmq.cloudamqp.com as lgfviuok
2018-03-18T16:18:47Z 62162 INFO -- opening rabbitmq channel with pool size 1, abort on exception false
2018-03-18T16:18:48Z 62162 INFO -- using topic exchange 'hutch'
2018-03-18T16:18:48Z 62162 INFO -- HTTP API use is disabled
2018-03-18T16:18:48Z 62162 INFO -- tracing is disabled
2018-03-18T16:18:48Z 62162 INFO -- setting up queues
2018-03-18T16:18:48Z 62162 INFO -- setting up queue: global_reports_consumer
2018-03-18T16:18:53Z 62162 ERROR -- undefined local variable or method `no_method' for #<GlobalReportsConsumer:0x00007fecad851e88>
2018-03-18T16:18:53Z 62162 ERROR -- [x] aborting consumer
Documents/global-reports [master●] »
```

cc @kinopyo 