### PR TITLE
Make default_topic_prefix a configurable value

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -1,6 +1,4 @@
 module Streamy
-  DEFAULT_TOPIC_PREFIX = "global"
-
   # External
   # TODO: Move into classes that use them
   require "active_support"
@@ -33,8 +31,9 @@ module Streamy
   require "streamy/railtie" if defined?(Rails)
 
   class << self
-    attr_accessor :message_bus, :logger, :cache
+    attr_accessor :message_bus, :logger, :cache, :default_topic_prefix
   end
 
   self.logger = SimpleLogger.new
+  self.default_topic_prefix = "global"
 end

--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -4,7 +4,7 @@ module Streamy
   module Consumer
     def self.included(base)
       base.include Hutch::Consumer
-      base.consume "#{Streamy::DEFAULT_TOPIC_PREFIX}.#"
+      base.consume "#{Streamy.default_topic_prefix}.#"
     end
 
     def process(message)

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -17,7 +17,7 @@ module Streamy
         attr_reader :params
 
         def routing_key
-          "#{Streamy::DEFAULT_TOPIC_PREFIX}.#{topic}.#{type}"
+          "#{Streamy.default_topic_prefix}.#{topic}.#{type}"
         end
 
         def topic


### PR DESCRIPTION
Regardless of where we go with the replay functionality, this seems like a useful feature.

It's a little tied to RabbitMQ at the moment, but could probably have equivalents in other message buses should we decide to switch.