### PR TITLE
Remove default consumption topic from consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Add consumer(s):
 # app/consumers/event_consumer.rb
 class EventConsumer
   include Streamy::Consumer
+
+  # Specify a topic to consume
+  consume "global.#"
 end
 ```
 

--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -4,7 +4,6 @@ module Streamy
   module Consumer
     def self.included(base)
       base.include Hutch::Consumer
-      base.consume "#{Streamy.default_topic_prefix}.#"
     end
 
     def process(message)

--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -3,6 +3,7 @@ require "active_support/cache/memory_store"
 
 class DummyConsumer
   include Streamy::Consumer
+  consume "global.#"
 end
 
 module EventHandlers


### PR DESCRIPTION
This avoids the problem when the inherited consumer tries to specify its own topic but ended up consuming Streamy's default topic as every subsequent `consume` call will join topics together.

https://github.com/gocardless/hutch/blob/bc367cb/lib/hutch/consumer.rb#L30-L32