### PR TITLE
Add `pause_consumer!` helper

### DIFF
--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -4,6 +4,19 @@ module Streamy
   module Consumer
     def self.included(base)
       base.include Hutch::Consumer
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def pause_consumer!
+        Hutch.consumers.delete self
+
+        Hutch::Config.setup_procs << Proc.new do
+          Hutch.logger.info("setting up paused queue: #{get_queue_name}")
+          queue = Hutch.broker.queue(get_queue_name, get_arguments)
+          Hutch.broker.bind_queue(queue, routing_keys)
+        end
+      end
     end
 
     def process(message)


### PR DESCRIPTION
This helper can be placed on top of the file to pause the consumer from consuming the event on the queue. The queue and the routing of the message will still be created as if this is a live consumer.

Usage:

    class SomeConsumer
      include Streamy::Consumer
      pause_consumer!
    end