### PR TITLE
Slightly different approach to 'replay mode'

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -31,9 +31,9 @@ module Streamy
   require "streamy/railtie" if defined?(Rails)
 
   class << self
-    attr_accessor :message_bus, :logger, :cache, :default_topic_prefix
+    attr_accessor :message_bus, :logger, :cache, :routing_prefix
   end
 
   self.logger = SimpleLogger.new
-  self.default_topic_prefix = "global"
+  self.routing_prefix = "global"
 end

--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -9,16 +9,22 @@ module Streamy
 
     module ClassMethods
       def replay(routing_key)
-        consume("replay.#{routing_key}")
-
+        # Set up keys / queues
+        replay_routing_key_prefix = "replay.#{get_queue_name}"
+        replay_routing_key = "#{replay_routing_key_prefix}.#{routing_key}"
         paused_queue = get_queue_name
         replay_queue = "#{paused_queue}_replay"
-        queue_name(replay_queue)
 
+        # Configure hutch
+        consume replay_routing_key
+        queue_name replay_queue
+
+        # Manually create "paused queue"
         Hutch::Config.setup_procs << Proc.new do
           Hutch.logger.info("setting up paused queue: #{paused_queue}")
           queue = Hutch.broker.queue(paused_queue, get_arguments)
           Hutch.broker.bind_queue(queue, [routing_key])
+          Hutch.logger.info("replay events using ROUTING_KEY_PREFIX=#{replay_routing_key_prefix}")
         end
       end
     end

--- a/lib/streamy/consumer.rb
+++ b/lib/streamy/consumer.rb
@@ -8,13 +8,17 @@ module Streamy
     end
 
     module ClassMethods
-      def pause_consumer!
-        Hutch.consumers.delete self
+      def replay(routing_key)
+        consume("replay.#{routing_key}")
+
+        paused_queue = get_queue_name
+        replay_queue = "#{paused_queue}_replay"
+        queue_name(replay_queue)
 
         Hutch::Config.setup_procs << Proc.new do
-          Hutch.logger.info("setting up paused queue: #{get_queue_name}")
-          queue = Hutch.broker.queue(get_queue_name, get_arguments)
-          Hutch.broker.bind_queue(queue, routing_keys)
+          Hutch.logger.info("setting up paused queue: #{paused_queue}")
+          queue = Hutch.broker.queue(paused_queue, get_arguments)
+          Hutch.broker.bind_queue(queue, [routing_key])
         end
       end
     end

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -17,7 +17,7 @@ module Streamy
         attr_reader :params
 
         def routing_key
-          "#{Streamy.default_topic_prefix}.#{topic}.#{type}"
+          "#{Streamy.routing_prefix}.#{topic}.#{type}"
         end
 
         def topic


### PR DESCRIPTION
Inspired by https://github.com/cookpad/streamy/pull/29
Needs cleaning up, but allows us to do:

```ruby
class GlobalReportsConsumer
  include Streamy::Consumer
  replay "global.#"
end
```

once done can switch to

```ruby
class GlobalReportsConsumer
  include Streamy::Consumer
  consume "global.#"
end
```

(but also need to "manually" avoid duplication with timestamp or something)

It will set up two queues, the "replay" queue binding to `replay.global_reports_consumer.global.#` (from which it will consume) and the "realtime" queue (from which I'm _hoping_ it won't consume 😅 now testing).