### PR TITLE
Allow Rails to control worker log level

### DIFF
--- a/lib/streamy/railties/consumer.rake
+++ b/lib/streamy/railties/consumer.rake
@@ -6,6 +6,7 @@ namespace :streamy do
         raise "Missing `rabbitmq_uri` for '#{Rails.env}' environment, set this value in `config/secrets.yml`"
       end
 
+      Hutch::Config[:log_level] = Rails.configuration.log_level
       Hutch::Config[:uri] = Rails.application.secrets.rabbitmq_uri
       Hutch::Config[:enable_http_api_use] = false
       Hutch::Config[:error_acknowledgements] << Streamy::RabbitMq::Acknowledgements::RequeueOnAllFailures.new


### PR DESCRIPTION
Gives us some nice extra output for development:

```
2018-04-19T02:21:20Z 38604 INFO -- setting up queues
2018-04-19T02:21:20Z 38604 INFO -- setting up queue: global_reports_consumer_replay
2018-04-19T02:21:20Z 38604 DEBUG -- creating binding global_reports_consumer_replay <--> replay.global.#
2018-04-19T02:21:20Z 38604 INFO -- setting up paused queue: global_reports_consumer
2018-04-19T02:21:20Z 38604 DEBUG -- creating binding global_reports_consumer <--> global.#
```