### PR TITLE
Treat routing key prefix as RabbitMQ-specific feature

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -30,9 +30,8 @@ module Streamy
   require "streamy/railtie" if defined?(Rails)
 
   class << self
-    attr_accessor :message_bus, :worker, :logger, :cache, :routing_key_prefix
+    attr_accessor :message_bus, :worker, :logger, :cache
   end
 
   self.logger = SimpleLogger.new
-  self.routing_key_prefix = "global"
 end

--- a/lib/streamy/message_buses/rabbit_message_bus.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus.rb
@@ -3,9 +3,10 @@ require "hutch"
 module Streamy
   module MessageBuses
     class RabbitMessageBus < MessageBus
-      def initialize(uri:)
+      def initialize(uri:, routing_key_prefix: "global")
         Hutch::Config.set(:uri, uri)
         Hutch::Config.set(:enable_http_api_use, false)
+        @routing_key_prefix = routing_key_prefix
       end
 
       def deliver(key:, topic:, type:, body:, event_time:)
@@ -14,9 +15,15 @@ module Streamy
           topic: topic,
           type: type,
           body: body,
-          event_time: event_time
+          event_time: event_time,
+          routing_key_prefix: routing_key_prefix
         ).publish
       end
+
+      private
+
+        attr_reader :routing_key_prefix
+
     end
   end
 end

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -3,7 +3,8 @@ require "hutch"
 module Streamy
   module MessageBuses
     class RabbitMessageBus::Message
-      def initialize(**params)
+      def initialize(routing_key_prefix:, **params)
+        @routing_key_prefix = routing_key_prefix
         @params = params
       end
 
@@ -14,10 +15,10 @@ module Streamy
 
       private
 
-        attr_reader :params
+        attr_reader :params, :routing_key_prefix
 
         def routing_key
-          "#{Streamy.routing_key_prefix}.#{topic}.#{type}"
+          "#{routing_key_prefix}.#{topic}.#{type}"
         end
 
         def topic

--- a/test/rabbit_message_bus_test.rb
+++ b/test/rabbit_message_bus_test.rb
@@ -10,5 +10,14 @@ module Streamy
 
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
     end
+
+    def test_deliver_with_custom_routing_prefix
+      bus = MessageBuses::RabbitMessageBus.new(uri: "valid_uri", routing_key_prefix: "replay.global")
+
+      Hutch.expects(:connect)
+      Hutch.expects(:publish).with("replay.global.topic.type", key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
+
+      bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
+    end
   end
 end


### PR DESCRIPTION
`routing_key` is a RabbitMQ-specific feature, so this PR moves it into the `RabbitMessageBus`