### PR TITLE
Add better error messages for missing event methods

### DIFF
--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -29,15 +29,15 @@ module Streamy
       end
 
       def topic
-        raise "topic not implemented on event"
+        raise "topic must be implemented on #{self.class}"
       end
 
       def body
-        raise "body not implemented on event"
+        raise "body must be implemented on #{self.class}"
       end
 
       def event_time
-        raise "event_time not implemented on event"
+        raise "event_time must be implemented on #{self.class}"
       end
   end
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module Streamy
+  class EventTest < Minitest::Test
+    class EventWithoutTopic < Event
+      def event_time; end
+      def body; end
+    end
+
+    class EventWithoutEventTime < Event
+      def topic; end
+      def body; end
+    end
+
+    class EventWithoutBody < Event
+      def topic; end
+      def event_time; end
+    end
+
+    def test_helpful_error_message_on_missing_topic
+      assert_runtime_error "topic must be implemented on Streamy::EventTest::EventWithoutTopic" do
+        EventWithoutTopic.publish
+      end
+    end
+
+    def test_helpful_error_message_on_missing_event_time
+      assert_runtime_error "event_time must be implemented on Streamy::EventTest::EventWithoutEventTime" do
+        EventWithoutEventTime.publish
+      end
+    end
+
+    def test_helpful_error_message_on_missing_body
+      assert_runtime_error "body must be implemented on Streamy::EventTest::EventWithoutBody" do
+        EventWithoutBody.publish
+      end
+    end
+
+    private
+
+      def assert_runtime_error(message, &block)
+        error = assert_raises RuntimeError do
+          yield
+        end
+
+        assert_equal message, error.message
+      end
+  end
+end


### PR DESCRIPTION
Got confused by:

```
     RuntimeError:
       event_time not implemented on event
```

when I accidentally removed `event_time` in an event 😅 

This PR tries to make it a little bit more obvious what is going by tweaking the error message.