### PR TITLE
Don't set prefix by default

### DIFF
--- a/lib/streamy/message_buses/rabbit_message_bus.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus.rb
@@ -3,7 +3,7 @@ require "hutch"
 module Streamy
   module MessageBuses
     class RabbitMessageBus < MessageBus
-      def initialize(uri:, routing_key_prefix: "global")
+      def initialize(uri:, routing_key_prefix: nil)
         Hutch::Config.set(:uri, uri)
         Hutch::Config.set(:enable_http_api_use, false)
         @routing_key_prefix = routing_key_prefix
@@ -23,7 +23,6 @@ module Streamy
       private
 
         attr_reader :routing_key_prefix
-
     end
   end
 end

--- a/lib/streamy/message_buses/rabbit_message_bus/message.rb
+++ b/lib/streamy/message_buses/rabbit_message_bus/message.rb
@@ -3,7 +3,7 @@ require "hutch"
 module Streamy
   module MessageBuses
     class RabbitMessageBus::Message
-      def initialize(routing_key_prefix:, **params)
+      def initialize(routing_key_prefix: nil, **params)
         @routing_key_prefix = routing_key_prefix
         @params = params
       end
@@ -18,7 +18,7 @@ module Streamy
         attr_reader :params, :routing_key_prefix
 
         def routing_key
-          "#{routing_key_prefix}.#{topic}.#{type}"
+          [routing_key_prefix, topic, type].compact.join(".")
         end
 
         def topic

--- a/test/rabbit_message_bus_test.rb
+++ b/test/rabbit_message_bus_test.rb
@@ -6,7 +6,7 @@ module Streamy
       bus = MessageBuses::RabbitMessageBus.new(uri: "valid_uri")
 
       Hutch.expects(:connect)
-      Hutch.expects(:publish).with("global.topic.type", key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
+      Hutch.expects(:publish).with("topic.type", key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
 
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
     end


### PR DESCRIPTION
In actual usage, I find the fact that messages get their routing key prefixed with `global` more confusing than helpful 😅 

Probably better to leave this control to individual event producers, to set it as part of their `topic`.

Ie

```rb
def topic
  "global-web.bookmarks"
end
```

for example.

Then consumers can specify what events they are interested in and where they come from.

```rb
# global-reports
consume "global-web.bookmarks.#"

# global-events
consume "#"

# maybe global-web?
consume "global-newsletters.something.#"
```

We however still need the feature of being able to configure the routing key for _replays_, so keeping that.