### PR TITLE
Revive timestamp filtering capability

### DIFF
--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -3,7 +3,11 @@ require "active_support/cache/memory_store"
 
 class DummyConsumer
   include Streamy::Consumer
-  consume "global.#"
+end
+
+class FilteringDummyConsumer
+  include Streamy::Consumer
+  start_from 1525058571
 end
 
 module EventHandlers
@@ -48,6 +52,14 @@ module Streamy
       DummyConsumer.new.process(message)
 
       assert_equal 2, EventHandlers::DummyEvent.times_called
+    end
+
+    def test_ignoring_messages_from_before_start_from
+      message = { key: "1234", event_time: "2018-04-30 03:22:50 UTC", type: "dummy_event" }
+
+      FilteringDummyConsumer.new.process(message)
+
+      assert_equal 0, EventHandlers::DummyEvent.times_called
     end
   end
 end


### PR DESCRIPTION
Will need this when switching from `replay` to avoid events already replayed also being consumed as realtime events once we switch out of replay mode and catch up with the realtime queue.