### PR TITLE
Change Kafka payload to JSON

### DIFF
--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -12,7 +12,7 @@ module Streamy
           body: body,
           event_time: event_time
         }
-        kafka.deliver_message(payload, topic: topic)
+        kafka.deliver_message(payload.to_json, topic: topic)
       end
 
       private

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -19,7 +19,8 @@ module Streamy
       bus = MessageBuses::KafkaMessageBus.new(kafka: fake_kafka)
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
 
-      assert_equal fake_kafka.messages, "topic" => { key: "key", type: "type", body: "body", event_time: "2018" }
+      assert_equal(fake_kafka.messages,
+                   "topic" => { key: "key", type: "type", body: "body", event_time: "2018" }.to_json)
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where we were trying to send a hash instead of a json payload.