### PR TITLE
Support Kafka key

### DIFF
--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -7,12 +7,11 @@ module Streamy
 
       def deliver(key:, topic:, type:, body:, event_time:)
         payload = {
-          key: key,
           type: type,
           body: body,
           event_time: event_time
         }
-        kafka.deliver_message(payload, topic: topic)
+        kafka.deliver_message(payload, key: key, topic: topic)
       end
 
       private

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -7,8 +7,8 @@ class FakeKafka
     @messages = {}
   end
 
-  def deliver_message(payload, topic:)
-    messages[topic] = payload
+  def deliver_message(payload, key:, topic:)
+    messages[key] = [topic, payload]
   end
 end
 
@@ -19,7 +19,7 @@ module Streamy
       bus = MessageBuses::KafkaMessageBus.new(kafka: fake_kafka)
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
 
-      assert_equal fake_kafka.messages, "topic" => { key: "key", type: "type", body: "body", event_time: "2018" }
+      assert_equal fake_kafka.messages, "key" => ["topic", { type: "type", body: "body", event_time: "2018" }]
     end
   end
 end


### PR DESCRIPTION
We can use the key argument outside of the payload to help us identify and compact messages later.

http://kafka.apache.org/documentation.html#compaction