### PR TITLE
Allow Streamy to configure Kafka message bus directly

### DIFF
--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -3,8 +3,8 @@ require "kafka"
 module Streamy
   module MessageBuses
     class KafkaMessageBus < MessageBus
-      def initialize(kafka: nil, config: nil)
-        @kafka = kafka || Kafka.new(config)
+      def initialize(config)
+        @kafka = Kafka.new(config)
       end
 
       def deliver(key:, topic:, type:, body:, event_time:)

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -1,8 +1,10 @@
+require "kafka"
+
 module Streamy
   module MessageBuses
     class KafkaMessageBus < MessageBus
-      def initialize(kafka:)
-        @kafka = kafka
+      def initialize(kafka: nil, config: nil)
+        @kafka = kafka || Kafka.new(config)
       end
 
       def deliver(key:, topic:, type:, body:, event_time:)

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", "~> 5.1"
   spec.add_dependency "hutch", "~> 0.25"
+  spec.add_dependency "ruby-kafka", "~> 0.6"
   spec.add_dependency "webmock", "~> 3.3"
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -15,16 +15,25 @@ end
 module Streamy
   class KafkaMessageBusTest < Minitest::Test
     def test_initialize_with_config
-      Kafka.expects(:new).with(seed_brokers: ["127.0.0.1:9092"], client_id: "test")
-      MessageBuses::KafkaMessageBus.new(config: { seed_brokers: ["127.0.0.1:9092"], client_id: "test" })
+      Kafka.expects(:new).with(config)
+
+      MessageBuses::KafkaMessageBus.new(config)
     end
 
     def test_deliver
       fake_kafka = FakeKafka.new
-      bus = MessageBuses::KafkaMessageBus.new(kafka: fake_kafka)
+      bus = MessageBuses::KafkaMessageBus.new(config)
+      bus.stubs(:kafka).returns(fake_kafka)
+
       bus.deliver(key: "key", topic: "topic", type: "type", body: "body", event_time: "2018")
 
       assert_equal fake_kafka.messages, "key" => ["topic", { type: "type", body: "body", event_time: "2018" }.to_json]
     end
+
+    private
+
+      def config
+        { seed_brokers: ["127.0.0.1:9092"], client_id: "test" }
+      end
   end
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -14,6 +14,11 @@ end
 
 module Streamy
   class KafkaMessageBusTest < Minitest::Test
+    def test_initialize_with_config
+      Kafka.expects(:new).with(seed_brokers: ["127.0.0.1:9092"], client_id: "test")
+      MessageBuses::KafkaMessageBus.new(config: { seed_brokers: ["127.0.0.1:9092"], client_id: "test" })
+    end
+
     def test_deliver
       fake_kafka = FakeKafka.new
       bus = MessageBuses::KafkaMessageBus.new(kafka: fake_kafka)


### PR DESCRIPTION
Rather than inject the Kafka dependency into the KafkaMessageBus, this PR allows passing just the configuration for Kafka in.