### PR TITLE
Support testing message key in RSpec

### DIFF
--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -3,9 +3,10 @@ require "streamy/helpers/have_hash_matcher"
 module Streamy
   module Helpers
     module RspecHelper
-      def expect_published_event(topic: kind_of(String), type:, body:, event_time: nil)
+      def expect_published_event(topic: kind_of(String), key: kind_of(String), type:, body:, event_time: nil)
         expect(Streamy.message_bus.deliveries).to have_hash(
           topic: topic,
+          key: key,
           type: type,
           body: body,
           event_time: event_time || kind_of(Time)


### PR DESCRIPTION
Small change to allow us to also test message key in RSpec helper, alongside other attributes.