### PR TITLE
allow fuzzier assertions

### DIFF
--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -3,7 +3,7 @@ require "streamy/helpers/have_hash_matcher"
 module Streamy
   module Helpers
     module RspecHelper
-      def expect_published_event(topic: kind_of(String), key: kind_of(String), type:, body:, event_time: nil)
+      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: nil)
         expect(Streamy.message_bus.deliveries).to have_hash(
           topic: topic,
           key: key,
@@ -12,6 +12,7 @@ module Streamy
           event_time: event_time || kind_of(Time)
         )
       end
+      alias expect_published_event expect_event
 
       Streamy.message_bus = MessageBuses::TestMessageBus.new
 

--- a/lib/streamy/helpers/test_unit_helper.rb
+++ b/lib/streamy/helpers/test_unit_helper.rb
@@ -1,7 +1,7 @@
 require "webmock/minitest"
 
 class ActiveSupport::TestCase
-  def assert_published_event(attributes = {})
+  def assert_event(attributes = {})
     deliveries = Streamy.message_bus.deliveries
 
     matching_event = deliveries.find do |delivery|
@@ -9,6 +9,7 @@ class ActiveSupport::TestCase
     end
     assert matching_event, "Didn't find event: \n\n #{attributes} \n\n in: #{deliveries.inspect}"
   end
+  alias assert_published_event assert_event
 end
 
 Streamy.message_bus = Streamy::MessageBuses::TestMessageBus.new


### PR DESCRIPTION
Closes https://github.com/cookpad/streamy/issues/47

Allows `body` to be left out of assertions, and shortens the helper name.