### PR TITLE
Remove logging around Kafka producer shutdown

### DIFF
--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -30,10 +30,8 @@ module Streamy
       end
 
       def shutdown
-        logger.info "Initiating graceful shutdown of Kafka Producers 🤞"
         async_producer.shutdown if async_producer?
         sync_producers.map(&:shutdown)
-        logger.info "Kafka producers shutdown successfully👌"
       end
 
       private


### PR DESCRIPTION
This is not required, and indeed can be a little missleading.

* Even if there are no producers (becuase no messages were sent) we still
log.

* If there were some errors shutting down the consumer we still see:
> Kafka producers shutdown successfully👌

* The logging that ruby-kafka does is OK... e.g. messages like:
> Failed to deliver messages during shutdown: Could not connect to any of the seed brokers:
> - kafka://localhost:9092: Connection refused - connect(2) for [::1]:9092