### PR TITLE
Consolidate global-reports / global-feed conventions

### DIFF
--- a/lib/streamy/event_handler.rb
+++ b/lib/streamy/event_handler.rb
@@ -1,23 +1,29 @@
 module Streamy
   class EventHandler
-    def initialize(attributes)
-      @attributes = attributes
+    def self.run(*args)
+      new(*args).run
     end
 
-    def process
+    def initialize(params)
+      @params = params.with_indifferent_access
+    end
+
+    def run
       raise "Not implemented"
     end
+    alias :process :run
 
     private
 
-      attr_reader :attributes
+      attr_reader :params
+      alias :attributes :params
 
       def event_time
-        attributes[:event_time]
+        params[:event_time]
       end
 
       def body
-        attributes[:body]
+        OpenStruct.new(params[:body])
       end
   end
 end

--- a/test/event_handler_test.rb
+++ b/test/event_handler_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+module Streamy
+  class DummyHandler < Streamy::EventHandler
+    def run
+      body
+    end
+  end
+
+  class EventHandlerTest < Minitest::Test
+    def test_accessing_body_as_hash
+      assert_equal "Title", DummyHandler.run(event)[:title]
+    end
+
+    def test_accessing_body_as_hash_with_string_key
+      assert_equal "Title", DummyHandler.run(event)["title"]
+    end
+
+    def test_accessing_body_as_object
+      assert_equal "Title", DummyHandler.run(event).title
+    end
+
+    private
+
+      def event
+        { body: { title: "Title" } }
+      end
+  end
+end


### PR DESCRIPTION
In preparation for hooking up global-reports to the kafka stream, am working on extracting some of the conventions to Streamy and consolidating them with some of the original ideas.

This takes some of what's found in https://github.com/cookpad/global-feeds/blob/master/app/handlers/application_handler.rb and adds it to the streamy `EventHandler`.