### PR TITLE
Add priority to rspec test helper

### DIFF
--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -3,7 +3,7 @@ require "streamy/helpers/have_hash_matcher"
 module Streamy
   module Helpers
     module RspecHelper
-      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
+      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), priority: kind_of(String))
         deliveries = hashify_messages(Streamy.message_bus.deliveries)
 
         expect(deliveries).to have_hash(
@@ -13,7 +13,8 @@ module Streamy
             body: body,
             type: type,
             event_time: event_time
-          }
+          },
+          priority: priority
         )
       end
 


### PR DESCRIPTION
It also makes sense to test the priority of an event.

Does it make sense to also use a slightly more extendable approach like we do with the ``assert_event`` helper and just accept all parameters? Probably then we can not do the ``kind_of`` expectations anymore?

I also was not able to try this out, not sure how you usually do it?
