### PR TITLE
Update spec helpers for events

### DIFF
--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -1,0 +1,30 @@
+require "avro_turf/messaging"
+
+module Streamy
+  module Helpers
+    module MessageParser
+      def hashify_messages(message_bus_deliveries, encoding_type)
+        message_bus_deliveries.map do |message|
+          message_hash = message.dup
+          message_hash[:payload] = parse_message(message_hash[:payload], encoding_type)
+          message_hash
+        end
+      end
+
+      def parse_message(message_payload, encoding_type)
+        if encoding_type == "avro"
+          avro.decode(message_payload).deep_symbolize_keys
+        else
+          JSON.parse(message_payload).deep_symbolize_keys
+        end
+      end
+
+      def avro
+        AvroTurf::Messaging.new(
+          registry_url: Streamy.configuration.avro_schema_registry_url,
+          schemas_path: Streamy.configuration.avro_schemas_path
+        )
+      end
+    end
+  end
+end

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -12,7 +12,7 @@ module Streamy
       end
 
       def parse_message(message_payload, encoding_type)
-        if encoding_type == "avro"
+        if encoding_type == :avro
           avro.decode(message_payload).deep_symbolize_keys
         else
           JSON.parse(message_payload).deep_symbolize_keys

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -1,9 +1,11 @@
 require "streamy/helpers/have_hash_matcher"
-require "avro_turf/messaging"
+require "streamy/helpers/message_parser"
 
 module Streamy
   module Helpers
     module RspecHelper
+      include Streamy::Helpers::MessageParser
+
       def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: "json")
         deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
 
@@ -34,31 +36,6 @@ module Streamy
           Streamy.message_bus.deliveries.clear
         end
       end
-
-      private
-
-        def hashify_messages(message_bus_deliveries, encoding_type)
-          message_bus_deliveries.map do |message|
-            message_hash = message.dup
-            message_hash[:payload] = parse_message(message_hash[:payload], encoding_type)
-            message_hash
-          end
-        end
-
-        def parse_message(message_payload, encoding_type)
-          if encoding_type == "avro"
-            avro.decode(message_payload).deep_symbolize_keys
-          else
-            JSON.parse(message_payload).deep_symbolize_keys
-          end
-        end
-
-        def avro
-          AvroTurf::Messaging.new(
-            registry_url: Streamy.configuration.avro_schema_registry_url,
-            schemas_path: Streamy.configuration.avro_schemas_path
-          )
-        end
     end
   end
 end

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,7 +6,7 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: "json")
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: :json)
         deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
 
         expect(deliveries).to have_hash(
@@ -22,7 +22,7 @@ module Streamy
       end
 
       def expect_avro_event(**options)
-        expect_event(**options, encoding: "avro")
+        expect_event(**options, encoding: :avro)
       end
 
       alias expect_published_event expect_event

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -1,10 +1,11 @@
 require "streamy/helpers/have_hash_matcher"
+require "avro_turf/messaging"
 
 module Streamy
   module Helpers
     module RspecHelper
-      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
-        deliveries = hashify_messages(Streamy.message_bus.deliveries)
+      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: "json")
+        deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
 
         expect(deliveries).to have_hash(
           topic: topic,
@@ -17,15 +18,12 @@ module Streamy
         )
       end
 
-      def hashify_messages(message_bus_deliveries)
-        message_bus_deliveries.map do |message|
-          message_hash = message.dup
-          message_hash[:payload] = JSON.parse(message_hash[:payload]).deep_symbolize_keys
-          message_hash
-        end
+      def expect_avro_event(**options)
+        expect_event(**options, encoding: "avro")
       end
 
       alias expect_published_event expect_event
+      alias expect_published_avro_event expect_avro_event
 
       Streamy.message_bus = MessageBuses::TestMessageBus.new
 
@@ -36,6 +34,31 @@ module Streamy
           Streamy.message_bus.deliveries.clear
         end
       end
+
+      private
+
+        def hashify_messages(message_bus_deliveries, encoding_type)
+          message_bus_deliveries.map do |message|
+            message_hash = message.dup
+            message_hash[:payload] = parse_message(message_hash[:payload], encoding_type)
+            message_hash
+          end
+        end
+
+        def parse_message(message_payload, encoding_type)
+          if encoding_type = "avro"
+            avro.decode(message_payload).deep_symbolize_keys
+          else
+            JSON.parse(message_payload).deep_symbolize_keys
+          end
+        end
+
+        def avro
+          AvroTurf::Messaging.new(
+            registry_url: Streamy.configuration.avro_schema_registry_url,
+            schemas_path: Streamy.configuration.avro_schemas_path
+          )
+        end
     end
   end
 end

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,10 +6,11 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: "json")
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: "json")
         deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
 
         expect(deliveries).to have_hash(
+          priority: priority,
           topic: topic,
           key: key,
           payload: {

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -46,7 +46,7 @@ module Streamy
         end
 
         def parse_message(message_payload, encoding_type)
-          if encoding_type = "avro"
+          if encoding_type == "avro"
             avro.decode(message_payload).deep_symbolize_keys
           else
             JSON.parse(message_payload).deep_symbolize_keys

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
 end


### PR DESCRIPTION
This PR updates the spec helper for rspec, allowing avro events to be tested, plus a bit of refactoring. It also includes the version bumped to `0.3.1`.

I have added a Kaizen issue for the updating of the spec helpers for minitest as discussed here https://github.com/cookpad/streamy/pull/62#pullrequestreview-223660846.