### PR TITLE
Update dependencies

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -24,10 +24,6 @@ module Streamy
   require "streamy/message_buses/message_bus"
   require "streamy/message_buses/test_message_bus"
 
-  # Avro
-  # require patches for avro to allow for logical types in schemas
-  require "avro_patches"
-
   class << self
     attr_accessor :message_bus, :worker, :logger, :cache
 

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,3 +1,6 @@
+# Avro
+# require patches for avro to allow for logical types in schemas
+require "avro_patches"
 require "avro_turf/messaging"
 
 module Streamy

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.1".freeze
+  VERSION = "0.3.2".freeze
 end


### PR DESCRIPTION
Moved requiring dependencies to the place we actually need to use it. This also fixes the deprecation error we were seeing for `Fixnum`