### PR TITLE
Silence test log output

### DIFF
--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -14,7 +14,8 @@ module Streamy
       def avro
         AvroTurf::Messaging.new(
           registry_url: Streamy.configuration.avro_schema_registry_url,
-          schemas_path: Streamy.configuration.avro_schemas_path
+          schemas_path: Streamy.configuration.avro_schemas_path,
+          logger: ::Streamy.logger
         )
       end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,3 +12,5 @@ def assert_runtime_error(message, &block)
 
   assert_equal message, error.message
 end
+
+Streamy.logger = Logger.new("test.log")


### PR DESCRIPTION
Tests shouldn't print anything to STDOUT. This does just add unnecessary noise to the output.


## Now
```
~/Projects/streamy (cb/silence_test_log_output) > bundle exec rake test
Run options: --seed 25526

# Running:

..........................

Finished in 0.021245s, 1223.8174 runs/s, 2071.0755 assertions/s.

26 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```

## Before

```
~/Projects/streamy (master) > bundle exec rake test
Run options: --seed 40570

# Running:

......2019-04-12 15:49:47 - Delivering 1000 batched events now
.2019-04-12 15:49:47 - Delivering 1000 batched events now
......I, [2019-04-12T15:49:47.950018 #94705]  INFO -- : Registered schema for subject `test_event`; id = 0
.I, [2019-04-12T15:49:47.952583 #94705]  INFO -- : Registered schema for subject `incorrect_attribute_event`; id = 0
............

Finished in 0.023478s, 1107.4197 runs/s, 1874.0949 assertions/s.

26 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```