### PR TITLE
Update rspec avro helper

### DIFF
--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -22,7 +22,7 @@ module Streamy
       end
 
       def expect_avro_event(**options)
-        expect_event(**options, encoding: :avro)
+        expect_event(**options, event_time: kind_of(Time), encoding: :avro)
       end
 
       alias expect_published_event expect_event

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.2".freeze
+  VERSION = "0.3.3".freeze
 end


### PR DESCRIPTION
This PR just updates the rspec avro helper to ensure that we have the correct value/format for time when we encode with avro. 