### PR TITLE
Implement a manual delivery of batched events

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ You can choose a priority for your events. This is done by overriding the `prior
 * `:essential` - The event will be sent to Kafka immediately. The call to publish is blocking, and may throw errors.
 * `:batched` - The event will be queued to send to Kafka, but no events are sent until `max_buffer_size` is reached. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
 
-It is also possible to manually trigger sending batched events by calling publish in a block. When exiting the block, all published events get send to the message bus.
+It is also possible to manually trigger sending batched events by calling publish in a block. When exiting the block, all published events get sent to the message bus.
 
 ```ruby
-ReceivedPayment.deliver do |event|
-  2.times do |i|
-    event.publish(i)
+ReceivedPaymentEvent.deliver do |event|
+  received_payments.each do |received_payment|
+    event.publish(received_payment)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ You can choose a priority for your events. This is done by overriding the `prior
 It is also possible to manually trigger sending batched events by calling publish in a block. When exiting the block, all published events get send to the message bus.
 
 ```ruby
-ReceivedPayment.deliver do |producer|
+ReceivedPayment.deliver do |event|
   2.times do |i|
-    producer.publish(i)
+    event.publish(i)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ You can choose a priority for your events. This is done by overriding the `prior
 * `:essential` - The event will be sent to Kafka immediately. The call to publish is blocking, and may throw errors.
 * `:batched` - The event will be queued to send to Kafka, but no events are sent until `max_buffer_size` is reached. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
 
+It is also possible to manually trigger sending batched events by calling publish in a block. When exiting the block, all published events get send to the message bus.
+
+```ruby
+ReceivedPayment.deliver do |producer|
+  2.times do |i|
+    producer.publish(i)
+  end
+end
+```
+
 ### Shutdown
 
 To ensure that all `:low` `:batched` or `:standard` priority events are published `Streamy.shutdown` should be called before your process exits to avoid losing any events.

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -26,6 +26,12 @@ module Streamy
       )
     end
 
+    def self.deliver
+      priority :batched
+      yield(self)
+      Streamy.message_bus.syncronized_deliver_messages
+    end
+
     private
 
       def priority

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -29,7 +29,7 @@ module Streamy
     def self.deliver
       priority :batched
       yield(self)
-      Streamy.message_bus.syncronized_deliver_messages
+      Streamy.message_bus.sync_producer_deliver_messages
     end
 
     private

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -6,7 +6,7 @@ require "active_support/json"
 module Streamy
   module MessageBuses
     class KafkaMessageBus < MessageBus
-      delegate :syncronized_deliver_messages, to: :sync_producer
+      delegate :deliver_messages, to: :sync_producer, prefix: true
 
       def initialize(config)
         @config = KafkaConfiguration.new(config)

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -6,6 +6,8 @@ require "active_support/json"
 module Streamy
   module MessageBuses
     class KafkaMessageBus < MessageBus
+      delegate :syncronized_deliver_messages, to: :sync_producer
+
       def initialize(config)
         @config = KafkaConfiguration.new(config)
         @kafka = Kafka.new(@config.kafka)

--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -1,13 +1,47 @@
 module Streamy
   module MessageBuses
     class TestMessageBus < MessageBus
-      cattr_accessor :deliveries do
-        []
+      attr_accessor :deliveries
+      attr_reader :buffer_size
+
+      def initialize(config: { max_buffer_size: 10 })
+        @config = config
+        @deliveries = []
+        @batched = []
+        @buffer_size = 0
       end
 
       def deliver(params = {})
-        deliveries << params
+        if params[:priority] == :batched
+          batched_deliver(params)
+        else
+          @deliveries << params
+        end
       end
+
+      def syncronized_deliver_messages
+        @deliveries += batched
+        @batched = []
+        deliveries
+      end
+
+      private
+
+        attr_reader :config, :batched
+
+        def batched_deliver(params = {})
+          @batched << params
+          @buffer_size += 1
+          deliver_messages if buffer_full?
+        end
+
+        def buffer_full?
+          config[:max_buffer_size] == buffer_size
+        end
+
+        def max_buffer_size
+          config[:max_buffer_size]
+        end
     end
   end
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -80,9 +80,9 @@ module Streamy
     def test_deliver_batched_events_in_block
       Streamy.message_bus = Streamy::MessageBuses::TestMessageBus.new
 
-      ValidEventWithParams.deliver do |producer|
+      ValidEventWithParams.deliver do |event|
         2.times do |i|
-          producer.publish(i)
+          event.publish(i)
         end
         assert_empty(Streamy.message_bus.deliveries)
       end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -8,6 +8,26 @@ module Streamy
       def event_time; end
     end
 
+    class ValidEventWithParams < Event
+      def initialize(i)
+        @i = i
+      end
+
+      def body
+        {
+          i: @i
+        }
+      end
+
+      def event_time
+        -"now"
+      end
+
+      def topic
+        -"valid_event_with_params_topic"
+      end
+    end
+
     class OveriddenPriority < ValidEvent
       priority :low
     end
@@ -55,6 +75,34 @@ module Streamy
       OveriddenPriority.publish
 
       assert_published_event(priority: :low)
+    end
+
+    def test_deliver_batched_events_in_block
+      Streamy.message_bus = Streamy::MessageBuses::TestMessageBus.new
+
+      ValidEventWithParams.deliver do |producer|
+        2.times do |i|
+          producer.publish(i)
+        end
+        assert_empty(Streamy.message_bus.deliveries)
+      end
+
+      assert_published_event(
+        topic: "valid_event_with_params_topic",
+        payload: {
+            type: "valid_event_with_params", 
+            body: { i: 0 }, 
+            event_time: "now"
+          }
+      )
+      assert_published_event(
+        topic: "valid_event_with_params_topic",
+        payload: {
+            type: "valid_event_with_params", 
+            body: { i: 1 }, 
+            event_time: "now"
+          }
+      )
     end
   end
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -91,11 +91,12 @@ module Streamy
     end
 
     def test_manually_deliver_batched_messages
+      sync_producer.stubs(:buffer_size).returns(0)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.expects(:syncronized_deliver_messages)
-      bus.syncronized_deliver_messages
+      sync_producer.expects(:deliver_messages)
+      bus.sync_producer_deliver_messages
     end
 
     def test_all_priority_delivery # rubocop:disable Metrics/AbcSize

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -90,6 +90,14 @@ module Streamy
       example_delivery(:batched)
     end
 
+    def test_manually_deliver_batched_messages
+      sync_producer.expects(:produce).with(*expected_event)
+      example_delivery(:batched)
+
+      sync_producer.expects(:syncronized_deliver_messages)
+      bus.syncronized_deliver_messages
+    end
+
     def test_all_priority_delivery # rubocop:disable Metrics/AbcSize
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)


### PR DESCRIPTION
It is now possible to manually send batch events by calling publish in a block. When exiting the block, all published events get send to the message bus.

 ```ruby
ReceivedPayment.deliver do |event|
  2.times each do |i|
    event.publish(i)
  end
end
```

## Open questions:
- [x] Currently there is also a ``batched`` mode which calls `deliver_messages` when the buffer size is reached. However, with this implementation, when calling the `deliver` block all produced messages are getting published. This could cause some unexpected side effects when using the `batch` mode. I don't know an easy way to get around that. IIRC the batch mode is currently not used so maybe we can just drop it to avoid confusion?
- [x] In the current implementation, the `KafkaMessageBus` delegates `deliver_messages` through to the `sync_producer` which seems not to be nice. Any other suggestions?
- [x] Are the adaption to the `TestMessageBus` necessary or do we no care in the specs that the messages do not get delivered before exiting the block?