### PR TITLE
Update message queue size

### DIFF
--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -5,14 +5,14 @@ module Streamy
       ack_timeout:         5,
       max_retries:         30,
       retry_backoff:       2,
-      max_buffer_size:     1000,
+      max_buffer_size:     10000,
       max_buffer_bytesize: 10_000_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {
-      max_queue_size:      1000,
-      delivery_threshold:  25,
-      delivery_interval:   5
+      max_queue_size:      5000,
+      delivery_threshold:  500,
+      delivery_interval:   10
     }.freeze
 
     DEFAULT_KAFKA_CONFIG = {

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -5,13 +5,13 @@ module Streamy
       ack_timeout:         5,
       max_retries:         30,
       retry_backoff:       2,
-      max_buffer_size:     10000,
+      max_buffer_size:     10_000,
       max_buffer_bytesize: 10_000_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {
-      max_queue_size:      5000,
-      delivery_threshold:  500,
+      max_queue_size:      5_000,
+      delivery_threshold:  100,
       delivery_interval:   10
     }.freeze
 

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.3".freeze
+  VERSION = "0.3.4".freeze
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -116,15 +116,15 @@ module Streamy
         ack_timeout:         5,
         max_retries:         30,
         retry_backoff:       2,
-        max_buffer_size:     10000,
+        max_buffer_size:     10_000,
         max_buffer_bytesize: 10_000_000
       ).returns(sync_producer)
 
       example_delivery(:essential)
 
       kafka.expects(:async_producer).with(
-        max_queue_size:      5000,
-        delivery_threshold:  500,
+        max_queue_size:      5_000,
+        delivery_threshold:  100,
         delivery_interval:   10,
         required_acks:       -1,
         ack_timeout:         5,

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -76,15 +76,15 @@ module Streamy
     end
 
     def test_batched_priority_deliver # rubocop:disable Metrics/AbcSize
-      sync_producer.stubs(:buffer_size).returns(998)
+      sync_producer.stubs(:buffer_size).returns(9998)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(999)
+      sync_producer.stubs(:buffer_size).returns(9999)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(1000)
+      sync_producer.stubs(:buffer_size).returns(10000)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
@@ -102,7 +102,7 @@ module Streamy
       async_producer.expects(:deliver_messages)
       example_delivery(:standard)
 
-      sync_producer.stubs(:buffer_size).returns(1000)
+      sync_producer.stubs(:buffer_size).returns(10000)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
@@ -116,21 +116,21 @@ module Streamy
         ack_timeout:         5,
         max_retries:         30,
         retry_backoff:       2,
-        max_buffer_size:     1000,
+        max_buffer_size:     10000,
         max_buffer_bytesize: 10_000_000
       ).returns(sync_producer)
 
       example_delivery(:essential)
 
       kafka.expects(:async_producer).with(
-        max_queue_size:      1000,
-        delivery_threshold:  25,
-        delivery_interval:   5,
+        max_queue_size:      5000,
+        delivery_threshold:  500,
+        delivery_interval:   10,
         required_acks:       -1,
         ack_timeout:         5,
         max_retries:         30,
         retry_backoff:       2,
-        max_buffer_size:     1000,
+        max_buffer_size:     10000,
         max_buffer_bytesize: 10_000_000
       ).returns(async_producer)
 


### PR DESCRIPTION
With all the new events that are being produced and the increase in existing events (more users) we keep reaching our max queue size as we are producing events at a faster rate than the producer can publish them to kafka. ([See explanation here](https://github.com/zendesk/ruby-kafka/blob/0f29b7605bdfc58808b880163acd5dc18ec7e409/lib/kafka/async_producer.rb#L33-L42))

We have mitigated that by setting some of our low-priority events to `:low` which means they will now be batch sent (500 at a time or every 10s whichever comes first).  I have also upped the `max_buffer_size` for the producing thread and the `max_queue_size` for the background thread in this PR. 

As a side note the standard java implementation of kafka sets the default `max_buffer_size` in bytes to `33554432` bytes which based on our message size of `194b` is approximately `172960` messages. (Our 10000 is well under this)

The 10000 `max_buffer_size` will also give us more room and more time to recover from any connection issues due to the `max_retries` config. 