### PR TITLE
Move bulk_deliver from Event to MessageBus class

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,9 @@ You can choose a priority for your events. This is done by overriding the `prior
 It is also possible to manually trigger sending batched events by calling publish in a block. When exiting the block, all published events get sent to the message bus.
 
 ```ruby
-ReceivedPaymentEvent.deliver do |event|
-  received_payments.each do |received_payment|
-    event.publish(received_payment)
-  end
+Streamy.bulk_deliver do
+  Events::ReceivedPayment.publish
+  Events::ReceivedPayment.publish
 end
 ```
 

--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -40,6 +40,10 @@ module Streamy
     yield(configuration)
   end
 
+  def self.bulk_deliver(&block)
+    message_bus.bulk_deliver &block
+  end
+
   self.logger = SimpleLogger.new
 end
 

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -26,12 +26,6 @@ module Streamy
       )
     end
 
-    def self.deliver
-      priority :batched
-      yield(self)
-      Streamy.message_bus.sync_producer_deliver_messages
-    end
-
     private
 
       def priority

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -10,6 +10,10 @@ module Streamy
       def deliver(key:, topic:, payload:, priority:)
         raise "not implemented"
       end
+
+      def bulk_deliver
+        raise "not implemented"
+      end
     end
   end
 end

--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -1,58 +1,17 @@
 module Streamy
   module MessageBuses
     class TestMessageBus < MessageBus
-      attr_accessor :deliveries
-
-      def initialize(config: { max_buffer_size: 10 })
-        @config = config
-        @deliveries = []
-        @batched = []
-        @buffer_size = 0
+      cattr_accessor :deliveries do
+        []
       end
 
       def deliver(params = {})
-        if params[:priority] == :batched
-          batch_messages [params]
-          sync_producer_deliver_messages if buffer_full?
-        else
-          deliver_messages [params]
-        end
+        deliveries << params
       end
 
-      def sync_producer_deliver_messages
-        deliver_messages batched
-        flush_batch
+      def bulk_deliver
+        yield
       end
-
-      private
-
-        attr_reader :config, :buffer_size, :batched
-
-        def deliver_messages(event)
-          @deliveries += event
-        end
-
-        def batch_messages(event)
-          increase_buffer
-          @batched += event
-        end
-
-        def increase_buffer
-          @buffer_size += 1
-        end
-
-        def flush_batch
-          @buffer_size = 0
-          @batched = []
-        end
-
-        def buffer_full?
-          max_buffer_size == buffer_size
-        end
-
-        def max_buffer_size
-          config[:max_buffer_size]
-        end
     end
   end
 end

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.4".freeze
+  VERSION = "0.3.5".freeze
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -76,33 +76,5 @@ module Streamy
 
       assert_published_event(priority: :low)
     end
-
-    def test_deliver_batched_events_in_block
-      Streamy.message_bus = Streamy::MessageBuses::TestMessageBus.new
-
-      ValidEventWithParams.deliver do |event|
-        2.times do |i|
-          event.publish(i)
-        end
-        assert_empty(Streamy.message_bus.deliveries)
-      end
-
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-            type: "valid_event_with_params", 
-            body: { i: 0 }, 
-            event_time: "now"
-          }
-      )
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-            type: "valid_event_with_params", 
-            body: { i: 1 }, 
-            event_time: "now"
-          }
-      )
-    end
   end
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -91,12 +91,21 @@ module Streamy
     end
 
     def test_manually_deliver_batched_messages
-      sync_producer.stubs(:buffer_size).returns(0)
-      sync_producer.expects(:produce).with(*expected_event)
-      example_delivery(:batched)
+      bus.bulk_deliver do
+        sync_producer.stubs(:buffer_size).returns(9999)
+        sync_producer.expects(:produce).with(*expected_event)
+        example_delivery(:standard)
+  
+        sync_producer.stubs(:buffer_size).returns(10_000)
+        sync_producer.expects(:produce).with(*expected_event)
+        sync_producer.expects(:deliver_messages)
+        example_delivery(:standard)
 
-      sync_producer.expects(:deliver_messages)
-      bus.sync_producer_deliver_messages
+        sync_producer.stubs(:buffer_size).returns(0)
+        sync_producer.expects(:produce).with(*expected_event)
+        example_delivery(:standard)
+        sync_producer.expects(:deliver_messages)
+      end
     end
 
     def test_all_priority_delivery # rubocop:disable Metrics/AbcSize

--- a/test/streamy_test.rb
+++ b/test/streamy_test.rb
@@ -9,4 +9,10 @@ class StreamyTest < Minitest::Test
   def test_shutdown_unsupported_message_bus
     Streamy.shutdown
   end
+
+  def test_bulk_deliver
+    Streamy.bulk_deliver do
+      # do nothing
+    end
+  end
 end


### PR DESCRIPTION
This PR follows up on https://github.com/cookpad/streamy/pull/74 to implement manually delivering events after invoking a block.

The event class shouldn't know about e.g. sync message bus in message bus so it makes sense to move this method over to the actual message bus.

This also exposes the API to send several different events in the same batch delivery, e.g.

```ruby
Streamy.bulk_deliver do
  Event.publish
  AnotherEvent.publish
end
```

Last but not least this enabled us to drop all the changes from the test message bus again (basically reverting it).

This is a follow up on this comment from @balvig https://github.com/cookpad/streamy/pull/74#issuecomment-484336940
