### PR TITLE
[WIP] Refactor test helpers

### DIFF
--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -9,6 +9,10 @@ module Streamy
       avro.encode(payload_attributes.deep_stringify_keys, schema_name: type)
     end
 
+    def encoding_format
+      "avro".freeze
+    end
+
     private
 
       def avro

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -22,7 +22,8 @@ module Streamy
         key: key,
         topic: topic,
         priority: priority,
-        payload: payload
+        payload: payload,
+        encoding_format: encoding_format
       )
     end
 
@@ -60,6 +61,10 @@ module Streamy
 
       def event_time
         raise "event_time must be implemented on #{self.class}"
+      end
+
+      def encoding_format
+        raise "encoding_format must be implemented on the abstract encoding class"
       end
 
       def payload_attributes

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -64,7 +64,7 @@ module Streamy
       end
 
       def encoding_format
-        raise "encoding_format must be implemented on the abstract encoding class"
+        raise "encoding_format must be implemented on the encoding class"
       end
 
       def payload_attributes

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -23,7 +23,7 @@ module Streamy
         topic: topic,
         priority: priority,
         payload: payload,
-        encoding_format: encoding_format
+        headers: headers
       )
     end
 
@@ -77,6 +77,12 @@ module Streamy
 
       def payload
         payload_attributes
+      end
+
+      def headers
+        {
+          encoding_format: encoding_format
+        }
       end
   end
 end

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -81,7 +81,7 @@ module Streamy
 
       def headers
         {
-          encoding_format: encoding_format
+          "EncodingFormat": encoding_format
         }
       end
   end

--- a/lib/streamy/helpers/assert_event.rb
+++ b/lib/streamy/helpers/assert_event.rb
@@ -1,9 +1,12 @@
+require "streamy/helpers/message_parser"
 require "webmock/minitest"
 
 module Streamy
   module AssertEvent
+    include Streamy::Helpers::MessageParser
+
     def assert_event(attributes = {})
-      deliveries = Streamy.message_bus.deliveries
+      deliveries = hashify_messages(Streamy.message_bus.deliveries)
 
       matching_event = deliveries.find do |delivery|
         hash_including(attributes) == delivery.deep_stringify_keys

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -5,8 +5,8 @@ module Streamy
     module MessageParser
       def hashify_messages(message_bus_deliveries)
         message_bus_deliveries.map do |message|
-          message_hash = message.dup
-          message_hash[:payload] = parse_message(message_hash[:payload], message_hash[:headers][:encoding_format])
+          message_hash = message.dup.with_indifferent_access
+          message_hash[:payload] = parse_message(message_hash[:payload], message_hash[:headers]["EncodingFormat"])
           message_hash
         end
       end

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -6,7 +6,7 @@ module Streamy
       def hashify_messages(message_bus_deliveries)
         message_bus_deliveries.map do |message|
           message_hash = message.dup
-          message_hash[:payload] = parse_message(message_hash[:payload], message_hash[:encoding_format])
+          message_hash[:payload] = parse_message(message_hash[:payload], message_hash[:headers][:encoding_format])
           message_hash
         end
       end

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -12,9 +12,10 @@ module Streamy
       end
 
       def parse_message(message_payload, encoding_format)
-        if encoding_format == "avro"
+        case encoding_format
+        when "avro"
           avro.decode(message_payload).deep_symbolize_keys
-        elsif encoding_format == "json"
+        when "json"
           JSON.parse(message_payload).deep_symbolize_keys
         else
           raise "Encoding format unknown, unable to parse message payload"

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -12,9 +12,9 @@ module Streamy
       end
 
       def parse_message(message_payload, encoding_format)
-        if encoding_format == :avro
+        if encoding_format == "avro"
           avro.decode(message_payload).deep_symbolize_keys
-        elsif encoding_format == :json
+        elsif encoding_format == "json"
           JSON.parse(message_payload).deep_symbolize_keys
         else
           raise "Encoding format unknown, unable to parse message payload"

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -6,15 +6,19 @@ module Streamy
       def hashify_messages(message_bus_deliveries)
         message_bus_deliveries.map do |message|
           message_hash = message.dup
-          message_hash[:payload] = parse_message(message_hash[:payload])
+          message_hash[:payload] = parse_message(message_hash[:payload], message_hash[:encoding_format])
           message_hash
         end
       end
 
-      def parse_message(message_payload)
-        JSON.parse(message_payload).deep_symbolize_keys
-      rescue JSON::ParserError
-        avro.decode(message_payload).deep_symbolize_keys
+      def parse_message(message_payload, encoding_format)
+        if encoding_format == :avro
+          avro.decode(message_payload).deep_symbolize_keys
+        elsif encoding_format == :json
+          JSON.parse(message_payload).deep_symbolize_keys
+        else
+          raise "Encoding format unknown, unable to parse message payload"
+        end
       end
 
       def avro

--- a/lib/streamy/helpers/message_parser.rb
+++ b/lib/streamy/helpers/message_parser.rb
@@ -3,20 +3,18 @@ require "avro_turf/messaging"
 module Streamy
   module Helpers
     module MessageParser
-      def hashify_messages(message_bus_deliveries, encoding_type)
+      def hashify_messages(message_bus_deliveries)
         message_bus_deliveries.map do |message|
           message_hash = message.dup
-          message_hash[:payload] = parse_message(message_hash[:payload], encoding_type)
+          message_hash[:payload] = parse_message(message_hash[:payload])
           message_hash
         end
       end
 
-      def parse_message(message_payload, encoding_type)
-        if encoding_type == :avro
-          avro.decode(message_payload).deep_symbolize_keys
-        else
-          JSON.parse(message_payload).deep_symbolize_keys
-        end
+      def parse_message(message_payload)
+        JSON.parse(message_payload).deep_symbolize_keys
+      rescue JSON::ParserError
+        avro.decode(message_payload).deep_symbolize_keys
       end
 
       def avro

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,8 +6,8 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: :json)
-        deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
+        deliveries = hashify_messages(Streamy.message_bus.deliveries)
 
         expect(deliveries).to have_hash(
           priority: priority,
@@ -22,7 +22,7 @@ module Streamy
       end
 
       def expect_avro_event(**options)
-        expect_event(**options, event_time: kind_of(Time), encoding: :avro)
+        expect_event(**options, event_time: kind_of(Time))
       end
 
       alias expect_published_event expect_event

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,7 +6,7 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: nil)
         deliveries = hashify_messages(Streamy.message_bus.deliveries)
 
         expect(deliveries).to have_hash(
@@ -16,17 +16,12 @@ module Streamy
           payload: {
             body: body,
             type: type,
-            event_time: event_time
+            event_time: kind_of(String) || kind_of(Time)
           }
         )
       end
 
-      def expect_avro_event(**options)
-        expect_event(**options, event_time: kind_of(Time))
-      end
-
       alias expect_published_event expect_event
-      alias expect_published_avro_event expect_avro_event
 
       Streamy.message_bus = MessageBuses::TestMessageBus.new
 

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,7 +6,7 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: nil)
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
         deliveries = hashify_messages(Streamy.message_bus.deliveries)
 
         expect(deliveries).to have_hash(
@@ -16,7 +16,7 @@ module Streamy
           payload: {
             body: body,
             type: type,
-            event_time: kind_of(String) || kind_of(Time)
+            event_time: event_time || kind_of(Time)
           }
         )
       end

--- a/lib/streamy/json_event.rb
+++ b/lib/streamy/json_event.rb
@@ -3,5 +3,9 @@ module Streamy
     def payload
       payload_attributes.to_json
     end
+
+    def encoding_format
+      "json".freeze
+    end
   end
 end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -13,9 +13,9 @@ module Streamy
         @kafka = Kafka.new(@config.kafka)
       end
 
-      def deliver(key:, topic:, payload:, priority:, encoding_format:)
+      def deliver(key:, topic:, payload:, priority:, headers:)
         producer(priority).tap do |p|
-          p.produce(payload, key: key, topic: topic, encoding_format: encoding_format)
+          p.produce(payload, key: key, topic: topic, headers: headers)
           case priority
           when :essential, :standard
             p.deliver_messages

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -13,9 +13,9 @@ module Streamy
         @kafka = Kafka.new(@config.kafka)
       end
 
-      def deliver(key:, topic:, payload:, priority:)
+      def deliver(key:, topic:, payload:, priority:, encoding_format:)
         producer(priority).tap do |p|
-          p.produce(payload, key: key, topic: topic)
+          p.produce(payload, key: key, topic: topic, encoding_format: encoding_format)
           case priority
           when :essential, :standard
             p.deliver_messages

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -7,7 +7,7 @@ module Streamy
         raise PublicationFailedError.new(e, *args)
       end
 
-      def deliver(key:, topic:, payload:, priority:, encoding_format:)
+      def deliver(key:, topic:, payload:, priority:, headers:)
         raise "not implemented"
       end
     end

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -7,7 +7,7 @@ module Streamy
         raise PublicationFailedError.new(e, *args)
       end
 
-      def deliver(key:, topic:, payload:, priority:)
+      def deliver(key:, topic:, payload:, priority:, encoding_format:)
         raise "not implemented"
       end
     end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -63,7 +63,6 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
-        encoding_format: "avro",
         payload: {
           type: "test_event",
           event_time: "nowish",
@@ -71,6 +70,9 @@ module Streamy
             smoked: "true",
             streaky: "false"
           }
+        },
+        headers: {
+          encoding_format: "avro"
         }
       )
     end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -63,6 +63,7 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
+        encoding_format: "avro",
         payload: {
           type: "test_event",
           event_time: "nowish",

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -47,7 +47,9 @@ module Streamy
 
     class EventWithNoSchema < AvroEvent
       def topic; end
+
       def body; end
+
       def event_time; end
     end
 
@@ -59,7 +61,14 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
-        payload: "\u0000\u0000\u0000\u0000\u0000\u0014test_event\u0002\fnowish\u0002\btrue\u0002\nfalse"
+        payload: {
+          type: "test_event",
+          event_time: "nowish",
+          body: {
+            smoked: "true",
+            streaky: "false"
+          }
+        }
       )
     end
 

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -72,7 +72,7 @@ module Streamy
           }
         },
         headers: {
-          encoding_format: "avro"
+          "EncodingFormat": "avro"
         }
       )
     end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -11,6 +11,10 @@ module Streamy
       stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
     end
 
+    def teardown
+      Streamy.message_bus.deliveries.clear
+    end
+
     class TestEvent < AvroEvent
       def topic
         :bacon
@@ -47,9 +51,7 @@ module Streamy
 
     class EventWithNoSchema < AvroEvent
       def topic; end
-
       def body; end
-
       def event_time; end
     end
 

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -5,16 +5,25 @@ module Streamy
     class EventWithoutTopic < Event
       def event_time; end
       def body; end
+      def encoding_format; end
     end
 
     class EventWithoutEventTime < Event
       def topic; end
       def body; end
+      def encoding_format; end
     end
 
     class EventWithoutBody < Event
       def topic; end
       def event_time; end
+      def encoding_format; end
+    end
+
+    class EventWithoutEncodingFormat < Event
+      def topic; end
+      def event_time; end
+      def body; end
     end
 
     def test_helpful_error_message_on_missing_topic
@@ -32,6 +41,12 @@ module Streamy
     def test_helpful_error_message_on_missing_body
       assert_runtime_error "body must be implemented on Streamy::EventTest::EventWithoutBody" do
         EventWithoutBody.publish
+      end
+    end
+
+    def test_helpful_error_message_on_missing_encoding_format
+      assert_runtime_error "encoding_format must be implemented on the encoding class" do
+        EventWithoutEncodingFormat.publish
       end
     end
   end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -2,36 +2,6 @@ require "test_helper"
 
 module Streamy
   class EventTest < Minitest::Test
-    class ValidEvent < Event
-      def topic; end
-      def body; end
-      def event_time; end
-    end
-
-    class ValidEventWithParams < Event
-      def initialize(i)
-        @i = i
-      end
-
-      def body
-        {
-          i: @i
-        }
-      end
-
-      def event_time
-        -"now"
-      end
-
-      def topic
-        -"valid_event_with_params_topic"
-      end
-    end
-
-    class OveriddenPriority < ValidEvent
-      priority :low
-    end
-
     class EventWithoutTopic < Event
       def event_time; end
       def body; end
@@ -63,43 +33,6 @@ module Streamy
       assert_runtime_error "body must be implemented on Streamy::EventTest::EventWithoutBody" do
         EventWithoutBody.publish
       end
-    end
-
-    def test_default_priority
-      ValidEvent.publish
-
-      assert_published_event(priority: :standard)
-    end
-
-    def test_overidden_priority
-      OveriddenPriority.publish
-
-      assert_published_event(priority: :low)
-    end
-
-    def test_deliver_batched_events_in_block
-      ValidEventWithParams.deliver do |event|
-        2.times do |i|
-          event.publish(i)
-        end
-      end
-
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-            type: "valid_event_with_params", 
-            body: { i: 0 }, 
-            event_time: "now"
-          }
-      )
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-            type: "valid_event_with_params", 
-            body: { i: 1 }, 
-            event_time: "now"
-          }
-      )
     end
   end
 end

--- a/test/json_event_test.rb
+++ b/test/json_event_test.rb
@@ -55,11 +55,13 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
-        encoding_format: "json",
         payload: {
           type: "test_event",
           body: { smoked: "true", streaky: "false" },
           event_time: "nowish"
+        },
+        headers: {
+          encoding_format: "json"
         }
       )
     end

--- a/test/json_event_test.rb
+++ b/test/json_event_test.rb
@@ -55,6 +55,7 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
+        encoding_format: "json",
         payload: {
           type: "test_event",
           body: { smoked: "true", streaky: "false" },

--- a/test/json_event_test.rb
+++ b/test/json_event_test.rb
@@ -61,7 +61,7 @@ module Streamy
           event_time: "nowish"
         },
         headers: {
-          encoding_format: "json"
+          "EncodingFormat": "json"
         }
       )
     end

--- a/test/json_event_test.rb
+++ b/test/json_event_test.rb
@@ -2,6 +2,10 @@ require "test_helper"
 
 module Streamy
   class JsonEventTest < Minitest::Test
+    def teardown
+      Streamy.message_bus.deliveries.clear
+    end
+
     class TestEvent < JsonEvent
       def topic
         :bacon

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -24,7 +24,8 @@ module Streamy
         payload: payload,
         key: "prk-sg-001",
         topic: "charcuterie",
-        priority: priority
+        priority: priority,
+        encoding_format: "json"
       )
     end
 
@@ -47,7 +48,8 @@ module Streamy
           event_time: "2018"
         }.to_json,
         key: "prk-sg-001",
-        topic: "charcuterie"
+        topic: "charcuterie",
+        encoding_format: "json"
       ]
     end
 

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -26,8 +26,8 @@ module Streamy
         topic: "charcuterie",
         priority: priority,
         headers: {
-          encoding_format: "json"
-        }
+          "EncodingFormat": "json"
+        }.stringify_keys
       )
     end
 
@@ -52,8 +52,8 @@ module Streamy
         key: "prk-sg-001",
         topic: "charcuterie",
         headers: {
-          encoding_format: "json"
-        }
+          "EncodingFormat": "json"
+        }.stringify_keys
       ]
     end
 

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -25,7 +25,9 @@ module Streamy
         key: "prk-sg-001",
         topic: "charcuterie",
         priority: priority,
-        encoding_format: "json"
+        headers: {
+          encoding_format: "json"
+        }
       )
     end
 
@@ -49,7 +51,9 @@ module Streamy
         }.to_json,
         key: "prk-sg-001",
         topic: "charcuterie",
-        encoding_format: "json"
+        headers: {
+          encoding_format: "json"
+        }
       ]
     end
 


### PR DESCRIPTION
Closes https://github.com/cookpad/streamy/issues/70 - Refactored the test helpers so that both minitest and rspec helpers function the same way. Also move some spec around to ensure they are in the correct spec class. 

I am also proposing to move some of the spec helpers such as `expect_no_event` to streamy in another PR. - See [here for helpers in `global-web`](https://github.com/cookpad/global-web/blob/6fd50d3b7d600b36dbd20720af003aa3a04e9a8e/spec/support/helpers/event_stream_helper.rb)

I will also update the documentation on spec helpers in a separate PR.
