### PR TITLE
Revert changes of test message bus

### DIFF
--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -1,58 +1,15 @@
 module Streamy
   module MessageBuses
     class TestMessageBus < MessageBus
-      attr_accessor :deliveries
-
-      def initialize(config: { max_buffer_size: 10 })
-        @config = config
-        @deliveries = []
-        @batched = []
-        @buffer_size = 0
+      cattr_accessor :deliveries do
+        []
       end
 
       def deliver(params = {})
-        if params[:priority] == :batched
-          batch_messages [params]
-          sync_producer_deliver_messages if buffer_full?
-        else
-          deliver_messages [params]
-        end
+        deliveries << params
       end
 
-      def sync_producer_deliver_messages
-        deliver_messages batched
-        flush_batch
-      end
-
-      private
-
-        attr_reader :config, :buffer_size, :batched
-
-        def deliver_messages(event)
-          @deliveries += event
-        end
-
-        def batch_messages(event)
-          increase_buffer
-          @batched += event
-        end
-
-        def increase_buffer
-          @buffer_size += 1
-        end
-
-        def flush_batch
-          @buffer_size = 0
-          @batched = []
-        end
-
-        def buffer_full?
-          max_buffer_size == buffer_size
-        end
-
-        def max_buffer_size
-          config[:max_buffer_size]
-        end
+      def sync_producer_deliver_messages; end
     end
   end
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -78,13 +78,10 @@ module Streamy
     end
 
     def test_deliver_batched_events_in_block
-      Streamy.message_bus = Streamy::MessageBuses::TestMessageBus.new
-
       ValidEventWithParams.deliver do |event|
         2.times do |i|
           event.publish(i)
         end
-        assert_empty(Streamy.message_bus.deliveries)
       end
 
       assert_published_event(


### PR DESCRIPTION
In https://github.com/cookpad/streamy/pull/74 we refactored
test message bus to handle delivering of messages based on the
priority. This changes made the test message bus flaky
so we're reverting it and also it did not make much sense to
implement functionality in a test helper for this use case.