### PR TITLE
Fix caching for schema registry

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -24,6 +24,9 @@ module Streamy
   require "streamy/message_buses/message_bus"
   require "streamy/message_buses/test_message_bus"
 
+  require "avro_patches"
+  require "avro_turf/messaging"
+
   class << self
     attr_accessor :message_bus, :worker, :logger, :cache
 
@@ -38,6 +41,14 @@ module Streamy
 
   def self.configure
     yield(configuration)
+  end
+
+  def self.avro_messaging
+    @_avro_messaging ||= AvroTurf::Messaging.new(
+      registry_url: Streamy.configuration.avro_schema_registry_url,
+      schemas_path: Streamy.configuration.avro_schemas_path,
+      logger: ::Streamy.logger
+    )
   end
 
   self.logger = SimpleLogger.new

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,22 +1,7 @@
-# Avro
-# require patches for avro to allow for logical types in schemas
-require "avro_patches"
-require "avro_turf/messaging"
-
 module Streamy
   class AvroEvent < Event
     def payload
-      avro.encode(payload_attributes.deep_stringify_keys, schema_name: type)
+      Streamy.avro_messaging.encode(payload_attributes.deep_stringify_keys, schema_name: type)
     end
-
-    private
-
-      def avro
-        AvroTurf::Messaging.new(
-          registry_url: Streamy.configuration.avro_schema_registry_url,
-          schemas_path: Streamy.configuration.avro_schemas_path,
-          logger: ::Streamy.logger
-        )
-      end
   end
 end

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.4".freeze
+  VERSION = "0.3.5".freeze
 end

--- a/test/fixtures/schemas/incorrect_attribute_event.avsc
+++ b/test/fixtures/schemas/incorrect_attribute_event.avsc
@@ -16,6 +16,7 @@
        "type": {
          "type": "record",
          "name": "body",
+         "namespace": "incorrect_attribute_event",
          "fields": [
            {
              "name": "smoked",

--- a/test/fixtures/schemas/test_event.avsc
+++ b/test/fixtures/schemas/test_event.avsc
@@ -16,6 +16,7 @@
        "type": {
          "type": "record",
          "name": "body",
+         "namespace": "test_event",
          "fields": [
            {
              "name": "smoked",


### PR DESCRIPTION
Closes https://github.com/cookpad/streamy/issues/81 - This PR fixes the performance related issues we were seeing, whereby the avro schema registry was being called every time an event was published. It should only be calling the registry the first time it publishes a new schema, or on app boot for each schema type. It should then be caching the schema locally. 

It also became apparent that namespaces are required on the body record of each event, as records can not have the same name. To that end the body for each avro event will be name-spaced using the event name. 

Once this has been merged I will update the existing avro events with the correct namespaces