### PR TITLE
[BLOCKING] Test helper refactoring

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -15,6 +15,10 @@ module Streamy
   require "streamy/profiler"
   require "streamy/simple_logger"
 
+  # Serializers
+  require "streamy/serializers/avro_serializer"
+  require "streamy/serializers/json_serializer"
+
   # Errors
   require "streamy/errors/event_handler_not_found_error"
   require "streamy/errors/publication_failed_error"

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,23 +1,7 @@
 module Streamy
   class AvroEvent < Event
-    def publish
-      validate_schema if test_environment?
-
-      super
-    end
-
     def serializer
       Serializers::AvroSerializer.new
     end
-
-    private
-
-      def test_environment?
-        ENV["RAILS_ENV"] == "test" || ::Rails.env.test?
-      end
-
-      def validate_schema
-        serializer.encode(payload)
-      end
   end
 end

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,7 +1,19 @@
 module Streamy
   class AvroEvent < Event
-    def payload
-      Streamy.avro_messaging.encode(payload_attributes.deep_stringify_keys, schema_name: type)
+    def publish
+      validate_schema
+
+      super
     end
+
+    def serializer
+      Serializers::AvroSerializer.new
+    end
+
+    private
+
+      def validate_schema
+        serializer.encode(payload)
+      end
   end
 end

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,7 +1,7 @@
 module Streamy
   class AvroEvent < Event
     def publish
-      validate_schema
+      validate_schema if Rails.env.test?
 
       super
     end

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,7 +1,7 @@
 module Streamy
   class AvroEvent < Event
     def publish
-      validate_schema if Rails.env.test?
+      validate_schema if test_environment?
 
       super
     end
@@ -11,6 +11,10 @@ module Streamy
     end
 
     private
+
+      def test_environment?
+        ENV["RAILS_ENV"] == "test" || ::Rails.env.test?
+      end
 
       def validate_schema
         serializer.encode(payload)

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -22,7 +22,8 @@ module Streamy
         key: key,
         topic: topic,
         priority: priority,
-        payload: payload
+        payload: payload,
+        serializer: serializer
       )
     end
 
@@ -62,16 +63,12 @@ module Streamy
         raise "event_time must be implemented on #{self.class}"
       end
 
-      def payload_attributes
+      def payload
         {
           type: type,
           body: body,
           event_time: event_time
         }
-      end
-
-      def payload
-        payload_attributes
       end
   end
 end

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,7 +6,7 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: nil)
         deliveries = Streamy.message_bus.deliveries
 
         expect(deliveries).to have_hash(
@@ -16,7 +16,7 @@ module Streamy
           payload: {
             body: body,
             type: type,
-            event_time: event_time
+            event_time: event_time || kind_of(Time)
           }
         )
       end

--- a/lib/streamy/helpers/rspec_helper.rb
+++ b/lib/streamy/helpers/rspec_helper.rb
@@ -6,8 +6,8 @@ module Streamy
     module RspecHelper
       include Streamy::Helpers::MessageParser
 
-      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String), encoding: :json)
-        deliveries = hashify_messages(Streamy.message_bus.deliveries, encoding)
+      def expect_event(topic: kind_of(String), priority: kind_of(Symbol), key: kind_of(String), body: kind_of(Hash), type:, event_time: kind_of(String))
+        deliveries = Streamy.message_bus.deliveries
 
         expect(deliveries).to have_hash(
           priority: priority,
@@ -21,12 +21,7 @@ module Streamy
         )
       end
 
-      def expect_avro_event(**options)
-        expect_event(**options, event_time: kind_of(Time), encoding: :avro)
-      end
-
       alias expect_published_event expect_event
-      alias expect_published_avro_event expect_avro_event
 
       Streamy.message_bus = MessageBuses::TestMessageBus.new
 

--- a/lib/streamy/json_event.rb
+++ b/lib/streamy/json_event.rb
@@ -1,7 +1,7 @@
 module Streamy
   class JsonEvent < Event
-    def payload
-      payload_attributes.to_json
+    def serializer
+      Serializers::JsonSerializer.new
     end
   end
 end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -13,9 +13,10 @@ module Streamy
         @kafka = Kafka.new(@config.kafka)
       end
 
-      def deliver(key:, topic:, payload:, priority:)
+      def deliver(key:, topic:, payload:, priority:, serializer:)
+        encoded_payload = serializer.encode(payload)
         producer(priority).tap do |p|
-          p.produce(payload, key: key, topic: topic)
+          p.produce(encoded_payload, key: key, topic: topic)
           case priority
           when :essential, :standard
             p.deliver_messages

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -7,7 +7,7 @@ module Streamy
         raise PublicationFailedError.new(e, *args)
       end
 
-      def deliver(key:, topic:, payload:, priority:)
+      def deliver(key:, topic:, payload:, priority:, serializer:)
         raise "not implemented"
       end
     end

--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -6,6 +6,8 @@ module Streamy
       end
 
       def deliver(params = {})
+        params[:serializer].encode(params[:payload])
+
         deliveries << params
       end
 

--- a/lib/streamy/serializers/avro_serializer.rb
+++ b/lib/streamy/serializers/avro_serializer.rb
@@ -1,0 +1,9 @@
+module Streamy
+  module Serializers
+    class AvroSerializer
+      def encode(payload_attributes)
+        Streamy.avro_messaging.encode(payload_attributes.deep_stringify_keys, schema_name: payload_attributes[:type])
+      end
+    end
+  end
+end

--- a/lib/streamy/serializers/json_serializer.rb
+++ b/lib/streamy/serializers/json_serializer.rb
@@ -1,0 +1,9 @@
+module Streamy
+  module Serializers
+    class JsonSerializer
+      def encode(payload_attributes)
+        payload_attributes.to_json
+      end
+    end
+  end
+end

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.3.5".freeze
+  VERSION = "0.3.6".freeze
 end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -68,15 +68,17 @@ module Streamy
     end
 
     def test_helpful_error_message_on_incorrect_attribute_type
-      assert_raises Avro::IO::AvroTypeError do
+      exception = assert_raises Streamy::PublicationFailedError do
         IncorrectAttributeEvent.publish
       end
+      assert_match("Avro::IO::AvroTypeError", exception.message)
     end
 
     def test_helpful_error_message_on_event_with_no_schema
-      assert_raises AvroTurf::SchemaNotFoundError do
+      exception = assert_raises Streamy::PublicationFailedError do
         EventWithNoSchema.publish
       end
+      assert_match("AvroTurf::SchemaNotFoundError", exception.message)
     end
   end
 end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -59,7 +59,11 @@ module Streamy
       assert_published_event(
         key: "IAMUUID",
         topic: :bacon,
-        payload: "\u0000\u0000\u0000\u0000\u0000\u0014test_event\u0002\fnowish\u0002\btrue\u0002\nfalse"
+        payload: {
+          type: "test_event",
+          body: { smoked: "true", streaky: "false" },
+          event_time: "nowish"
+        }
       )
     end
 

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -2,13 +2,13 @@ require "test_helper"
 
 module Streamy
   class EventTest < Minitest::Test
-    class ValidEvent < Event
+    class ValidEvent < JsonEvent
       def topic; end
       def body; end
       def event_time; end
     end
 
-    class ValidEventWithParams < Event
+    class ValidEventWithParams < JsonEvent
       def initialize(i)
         @i = i
       end
@@ -32,17 +32,17 @@ module Streamy
       priority :low
     end
 
-    class EventWithoutTopic < Event
+    class EventWithoutTopic < JsonEvent
       def event_time; end
       def body; end
     end
 
-    class EventWithoutEventTime < Event
+    class EventWithoutEventTime < JsonEvent
       def topic; end
       def body; end
     end
 
-    class EventWithoutBody < Event
+    class EventWithoutBody < JsonEvent
       def topic; end
       def event_time; end
     end
@@ -87,18 +87,18 @@ module Streamy
       assert_published_event(
         topic: "valid_event_with_params_topic",
         payload: {
-            type: "valid_event_with_params", 
-            body: { i: 0 }, 
-            event_time: "now"
-          }
+          type: "valid_event_with_params",
+          body: { i: 0 },
+          event_time: "now"
+        }
       )
       assert_published_event(
         topic: "valid_event_with_params_topic",
         payload: {
-            type: "valid_event_with_params", 
-            body: { i: 1 }, 
-            event_time: "now"
-          }
+          type: "valid_event_with_params",
+          body: { i: 1 },
+          event_time: "now"
+        }
       )
     end
   end

--- a/test/json_event_test.rb
+++ b/test/json_event_test.rb
@@ -31,7 +31,7 @@ module Streamy
           type: "test_event",
           body: { smoked: "true", streaky: "false" },
           event_time: "nowish"
-        }.to_json
+        }
       )
     end
   end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -24,7 +24,8 @@ module Streamy
         payload: payload,
         key: "prk-sg-001",
         topic: "charcuterie",
-        priority: priority
+        priority: priority,
+        serializer: Serializers::JsonSerializer.new
       )
     end
 
@@ -33,7 +34,7 @@ module Streamy
         type: "sausage",
         body: { meat: "pork", herbs: "sage" },
         event_time: "2018"
-      }.to_json
+      }
     end
 
     def expected_event

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,3 @@
-ENV["RAILS_ENV"] ||= "test"
-
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "streamy"
 require "minitest/autorun"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+ENV["RAILS_ENV"] ||= "test"
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "streamy"
 require "minitest/autorun"


### PR DESCRIPTION
Closes https://github.com/cookpad/streamy/issues/70 - This PR is a refactor of the way we encode our messages in both `avro` and `json`. I feel it's a nicer/cleaner way of encoding the messages. It also helps us test events more effectively. We don't need to test the types of encoding in the main rails app. (That is already tested in the encoding libraries.)

This allows us to go back to the familiar `expect_event` syntax of old. The rails app should not care about the encoding of the message, only that the event was published to the event bus.

This is actually blocking me from enabling more avro events, so would be great to get this merged asap. 