### PR TITLE
refactor avro serialization

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -7,17 +7,15 @@ module Streamy
   require "streamy/version"
   require "streamy/configuration"
   require "streamy/consumer"
-  require "streamy/event"
-  require "streamy/json_event"
-  require "streamy/avro_event"
   require "streamy/event_handler"
   require "streamy/message_processor"
   require "streamy/profiler"
   require "streamy/simple_logger"
 
-  # Serializers
-  require "streamy/serializers/avro_serializer"
-  require "streamy/serializers/json_serializer"
+  # Event types
+  require "streamy/event"
+  require "streamy/json_event"
+  require "streamy/avro_event"
 
   # Errors
   require "streamy/errors/event_handler_not_found_error"
@@ -27,9 +25,6 @@ module Streamy
   # Message Buses
   require "streamy/message_buses/message_bus"
   require "streamy/message_buses/test_message_bus"
-
-  require "avro_patches"
-  require "avro_turf/messaging"
 
   class << self
     attr_accessor :message_bus, :worker, :logger, :cache
@@ -45,14 +40,6 @@ module Streamy
 
   def self.configure
     yield(configuration)
-  end
-
-  def self.avro_messaging
-    @_avro_messaging ||= AvroTurf::Messaging.new(
-      registry_url: Streamy.configuration.avro_schema_registry_url,
-      schemas_path: Streamy.configuration.avro_schemas_path,
-      logger: ::Streamy.logger
-    )
   end
 
   self.logger = SimpleLogger.new

--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -1,5 +1,7 @@
 module Streamy
   class AvroEvent < Event
+    require "streamy/serializers/avro_serializer"
+
     def serializer
       Serializers::AvroSerializer.new
     end

--- a/lib/streamy/json_event.rb
+++ b/lib/streamy/json_event.rb
@@ -1,5 +1,7 @@
 module Streamy
   class JsonEvent < Event
+    require "streamy/serializers/json_serializer"
+
     def serializer
       Serializers::JsonSerializer.new
     end

--- a/lib/streamy/serializers/avro_serializer.rb
+++ b/lib/streamy/serializers/avro_serializer.rb
@@ -1,8 +1,23 @@
 module Streamy
   module Serializers
     class AvroSerializer
-      def encode(payload_attributes)
-        Streamy.avro_messaging.encode(payload_attributes.deep_stringify_keys, schema_name: payload_attributes[:type])
+      require "avro_patches"
+      require "avro_turf/messaging"
+
+      def self.messaging
+        @_messaging ||= connect_avro
+      end
+
+      def self.connect_avro
+        AvroTurf::Messaging.new(
+          registry_url: Streamy.configuration.avro_schema_registry_url,
+          schemas_path: Streamy.configuration.avro_schemas_path,
+          logger: ::Streamy.logger
+        )
+      end
+
+      def encode(payload)
+        self.class.messaging.encode(payload.deep_stringify_keys, schema_name: payload[:type])
       end
     end
   end

--- a/lib/streamy/serializers/json_serializer.rb
+++ b/lib/streamy/serializers/json_serializer.rb
@@ -1,8 +1,8 @@
 module Streamy
   module Serializers
     class JsonSerializer
-      def encode(payload_attributes)
-        payload_attributes.to_json
+      def encode(payload)
+        payload.to_json
       end
     end
   end


### PR DESCRIPTION
Partially addresses point raised by @sebasoga in https://github.com/cookpad/streamy/pull/82#discussion_r281261212:

> the original idea was to keep Streamy message-bus/format agnostic as much as possible 

I agree that the avro related code feels out of place on the `Streamy` module. Imagine that we added another type of serialization, the top-most module could quickly become a junk drawer of different serialization-related methods?

Moving it inside the serializer feels a bit more intuitive to me, and could also open up possibilities of making the loading of _any_ avro classes optional, ie to be triggered by `require "serializers/avro_serializer"` instead of always coming along with requiring Streamy.