### PR TITLE
Relax Active Support version so we can run on 6.0

### DIFF
--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "ruby-kafka", "~> 0.6"
   spec.add_development_dependency "sinatra"
 
-  spec.add_dependency "activesupport", "~> 5.2"
+  spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "avro-patches"
   spec.add_dependency "avro_turf", "~> 0.8.1"
   spec.add_dependency "webmock", "~> 3.3"


### PR DESCRIPTION
Since we want to be able to test Streamy with newer version of Rails, including Rails 6, we should only specify the minimum required version and open up the upper bound.

With this, we can says that we only support running Streamy with the stable version of Rails, but user can choose to run Streamy against edge Rails at their own risk.