### PR TITLE
Dd/udpate avro gem [DO NOT MERGE]

### DIFF
--- a/lib/streamy/serializers/avro_serializer.rb
+++ b/lib/streamy/serializers/avro_serializer.rb
@@ -1,7 +1,6 @@
 module Streamy
   module Serializers
     class AvroSerializer
-      require "avro_patches"
       require "avro_turf/messaging"
 
       def self.messaging

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "0.4.0".freeze
+  VERSION = "0.4.1".freeze
 end

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "sinatra"
 
   spec.add_dependency "activesupport", ">= 5.2"
-  spec.add_dependency "avro-patches"
-  spec.add_dependency "avro_turf", "~> 0.8.1"
+  spec.add_dependency "avro_turf", "~> 0.9"
   spec.add_dependency "webmock", "~> 3.3"
 end


### PR DESCRIPTION
We can update `avro_turf` to `0.9.0` and remove the avro-patches gem, as there are no patches required any longer. However, we need to wait until karafka is updated to use `avro ~> 1.9`

Keeping this here, as karafka should be updated in the next week or so.

