### PR TITLE
Double check `batched` implementation

### DIFF
--- a/lib/streamy/configuration.rb
+++ b/lib/streamy/configuration.rb
@@ -1,10 +1,11 @@
 module Streamy
   class Configuration
-    attr_accessor :avro_schema_registry_url, :avro_schemas_path
+    attr_accessor :avro_schema_registry_url, :avro_schemas_path, :producer_batched_message_limit
 
     def initialize
       @avro_schema_registry_url = nil
       @avro_schemas_path = nil
+      @producer_batched_message_limit = 1000
     end
   end
 end

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -27,12 +27,6 @@ module Streamy
       )
     end
 
-    def self.deliver
-      priority :batched
-      yield(self)
-      Streamy.message_bus.sync_producer_deliver_messages
-    end
-
     private
 
       def priority

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -1,18 +1,18 @@
 module Streamy
   class KafkaConfiguration < SimpleDelegator
     DEFAULT_PRODUCER_CONFIG = {
-      required_acks:       -1, # all replicas
-      ack_timeout:         5,
-      max_retries:         30,
-      retry_backoff:       2,
-      max_buffer_size:     10_000,
+      required_acks: -1, # all replicas
+      ack_timeout: 5,
+      max_retries: 30,
+      retry_backoff: 2,
+      max_buffer_size: 10_000,
       max_buffer_bytesize: 10_000_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {
-      max_queue_size:      5_000,
-      delivery_threshold:  100,
-      delivery_interval:   10
+      max_queue_size: 5_000,
+      delivery_threshold: 100,
+      delivery_interval: 10
     }.freeze
 
     DEFAULT_KAFKA_CONFIG = {

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -21,7 +21,7 @@ module Streamy
           when :essential, :standard
             p.deliver_messages
           when :batched
-            if config.producer[:max_buffer_size] == p.buffer_size
+            if p.buffer_size == batched_message_size
               logger.info "Delivering #{p.buffer_size} batched events now"
               p.deliver_messages
             end
@@ -70,6 +70,10 @@ module Streamy
 
         def logger
           ::Streamy.logger
+        end
+
+        def batched_message_size
+          Streamy.configuration.producer_batched_message_limit
         end
     end
   end

--- a/lib/streamy/message_buses/test_message_bus.rb
+++ b/lib/streamy/message_buses/test_message_bus.rb
@@ -10,8 +10,6 @@ module Streamy
 
         deliveries << params
       end
-
-      def sync_producer_deliver_messages; end
     end
   end
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -8,26 +8,6 @@ module Streamy
       def event_time; end
     end
 
-    class ValidEventWithParams < JsonEvent
-      def initialize(i)
-        @i = i
-      end
-
-      def body
-        {
-          i: @i
-        }
-      end
-
-      def event_time
-        -"now"
-      end
-
-      def topic
-        -"valid_event_with_params_topic"
-      end
-    end
-
     class OveriddenPriority < ValidEvent
       priority :low
     end
@@ -75,31 +55,6 @@ module Streamy
       OveriddenPriority.publish
 
       assert_published_event(priority: :low)
-    end
-
-    def test_deliver_batched_events_in_block
-      ValidEventWithParams.deliver do |event|
-        2.times do |i|
-          event.publish(i)
-        end
-      end
-
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-          type: "valid_event_with_params",
-          body: { i: 0 },
-          event_time: "now"
-        }
-      )
-      assert_published_event(
-        topic: "valid_event_with_params_topic",
-        payload: {
-          type: "valid_event_with_params",
-          body: { i: 1 },
-          event_time: "now"
-        }
-      )
     end
   end
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -77,27 +77,18 @@ module Streamy
     end
 
     def test_batched_priority_deliver # rubocop:disable Metrics/AbcSize
-      sync_producer.stubs(:buffer_size).returns(9998)
+      sync_producer.stubs(:buffer_size).returns(998)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(9999)
+      sync_producer.stubs(:buffer_size).returns(999)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(10000)
+      sync_producer.stubs(:buffer_size).returns(1000)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
-    end
-
-    def test_manually_deliver_batched_messages
-      sync_producer.stubs(:buffer_size).returns(0)
-      sync_producer.expects(:produce).with(*expected_event)
-      example_delivery(:batched)
-
-      sync_producer.expects(:deliver_messages)
-      bus.sync_producer_deliver_messages
     end
 
     def test_all_priority_delivery # rubocop:disable Metrics/AbcSize
@@ -112,7 +103,7 @@ module Streamy
       async_producer.expects(:deliver_messages)
       example_delivery(:standard)
 
-      sync_producer.stubs(:buffer_size).returns(10000)
+      sync_producer.stubs(:buffer_size).returns(1000)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
@@ -122,25 +113,25 @@ module Streamy
       stub_producers
 
       kafka.expects(:producer).with(
-        required_acks:       -1,
-        ack_timeout:         5,
-        max_retries:         30,
-        retry_backoff:       2,
-        max_buffer_size:     10_000,
+        required_acks: -1,
+        ack_timeout: 5,
+        max_retries: 30,
+        retry_backoff: 2,
+        max_buffer_size: 10_000,
         max_buffer_bytesize: 10_000_000
       ).returns(sync_producer)
 
       example_delivery(:essential)
 
       kafka.expects(:async_producer).with(
-        max_queue_size:      5_000,
-        delivery_threshold:  100,
-        delivery_interval:   10,
-        required_acks:       -1,
-        ack_timeout:         5,
-        max_retries:         30,
-        retry_backoff:       2,
-        max_buffer_size:     10000,
+        max_queue_size: 5_000,
+        delivery_threshold: 100,
+        delivery_interval: 10,
+        required_acks: -1,
+        ack_timeout: 5,
+        max_retries: 30,
+        retry_backoff: 2,
+        max_buffer_size: 10_000,
         max_buffer_bytesize: 10_000_000
       ).returns(async_producer)
 
@@ -149,14 +140,14 @@ module Streamy
 
     def test_config_overides
       @config = {
-        max_queue_size:      1,
-        delivery_threshold:  1,
-        delivery_interval:   1,
-        required_acks:       1,
-        ack_timeout:         1,
-        max_retries:         1,
-        retry_backoff:       1,
-        max_buffer_size:     1,
+        max_queue_size: 1,
+        delivery_threshold: 1,
+        delivery_interval: 1,
+        required_acks: 1,
+        ack_timeout: 1,
+        max_retries: 1,
+        retry_backoff: 1,
+        max_buffer_size: 1,
         max_buffer_bytesize: 1
       }
 
@@ -165,25 +156,25 @@ module Streamy
       stub_producers
 
       kafka.expects(:producer).with(
-        required_acks:       1,
-        ack_timeout:         1,
-        max_retries:         1,
-        retry_backoff:       1,
-        max_buffer_size:     1,
+        required_acks: 1,
+        ack_timeout: 1,
+        max_retries: 1,
+        retry_backoff: 1,
+        max_buffer_size: 1,
         max_buffer_bytesize: 1
       ).returns(sync_producer)
 
       example_delivery(:essential)
 
       kafka.expects(:async_producer).with(
-        max_queue_size:      1,
-        delivery_threshold:  1,
-        delivery_interval:   1,
-        required_acks:       1,
-        ack_timeout:         1,
-        max_retries:         1,
-        retry_backoff:       1,
-        max_buffer_size:     1,
+        max_queue_size: 1,
+        delivery_threshold: 1,
+        delivery_interval: 1,
+        required_acks: 1,
+        ack_timeout: 1,
+        max_retries: 1,
+        retry_backoff: 1,
+        max_buffer_size: 1,
         max_buffer_bytesize: 1
       ).returns(async_producer)
 
@@ -192,14 +183,14 @@ module Streamy
 
     def test_client_config
       producer_config = {
-        max_queue_size:      2,
-        delivery_threshold:  2,
-        delivery_interval:   2,
-        required_acks:       2,
-        ack_timeout:         2,
-        max_retries:         2,
-        retry_backoff:       2,
-        max_buffer_size:     2,
+        max_queue_size: 2,
+        delivery_threshold: 2,
+        delivery_interval: 2,
+        required_acks: 2,
+        ack_timeout: 2,
+        max_retries: 2,
+        retry_backoff: 2,
+        max_buffer_size: 2,
         max_buffer_bytesize: 2
       }
 


### PR DESCRIPTION
Closes cookpad/streamy#77

This PR fixes the `:batched` event publishing implementation. This was causing issues due to [this](https://github.com/zendesk/ruby-kafka/blob/93c45a8c531e8b447f1cd9127c8bc6ce8070c0e6/lib/kafka/producer.rb#L199-L202) in ruby-kafka as we would only send batched messages when the `max_buffer_size` had been reached, causing `Kafka::BufferOverflow` errors.

I have provided a setting in config now, whereby you can set a `producer_batched_message_limit`, this ensures that the messages are sent in batches of `1000` as default. This can be set in the config. 

 The `producer_batched_message_limit` should always be set below `max_buffer_size` otherwise buffer overflow errors will occur.

This also means we can remove the `Event.deliver` implementation as discussed here https://github.com/cookpad/streamy/pull/87#issuecomment-498102999, so once this is merged and released, I can merge https://github.com/cookpad/streamy/pull/87 and then update the implementation in `global-web` for batched events (e.g `SeenFeedItem`)