### PR TITLE
Updates to batched mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,14 +194,15 @@ You can choose a priority for your events. This is done by overriding the `prior
 * `:low` - The event will be sent to Kafka by a background thread, events are buffered until `delivery_threshold` messages are waiting or until `delivery_interval` seconds have passed since the last delivery. Calling publish on a low priority event is non blocking, and no errors should be thrown, unless the buffer is full.
 * `:standard` (default) - The event will be sent to Kafka by a background thread, but the thread is signaled to send any buffered events as soon as possible. The call to publish is non blocking, and should not throw errors, unless the buffer is full.
 * `:essential` - The event will be sent to Kafka immediately. The call to publish is blocking, and may throw errors.
-* `:batched` - The event will be queued to send to Kafka using a synchronous producer, but no events are sent until `producer_batched_message_limit` is reached. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
+* `:batched` - The event will be queued to send to Kafka using a synchronous producer, but no events are sent until `batched_message_limit` is reached or the synchronous producer in the specific thread has `deliver_messages` called by another service. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
 
-This can be set in the config for Streamy. (The default is `1000` messages in a batch). Be aware you should set this below the default `max_buffer_size` of `10_000`, as you will get `Kafka::BufferOverflow` errors and you would not be able to send batched messages.
+This can be set in the config for Streamy. (The default is `1000` messages in a batch). Be aware you should set this below the default `max_buffer_size` of `10_000`, as you will get `Kafka::BufferOverflow` errors and you would not be able to send batched messages. It can be set in the Streamy initializer in your host application as below.
 
 ```ruby
-Streamy.configure do |config|
-  config.producer_batched_message_limit = 1000
-end
+  require "streamy/message_buses/kafka_message_bus"
+  Streamy.message_bus = Streamy::MessageBuses::KafkaMessageBus.new(
+    batched_message_limit: 1000
+  )
 ```
 
 ### Shutdown

--- a/lib/streamy/configuration.rb
+++ b/lib/streamy/configuration.rb
@@ -1,11 +1,10 @@
 module Streamy
   class Configuration
-    attr_accessor :avro_schema_registry_url, :avro_schemas_path, :producer_batched_message_limit
+    attr_accessor :avro_schema_registry_url, :avro_schemas_path
 
     def initialize
       @avro_schema_registry_url = nil
       @avro_schemas_path = nil
-      @producer_batched_message_limit = 1000
     end
   end
 end

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -6,7 +6,8 @@ module Streamy
       max_retries: 30,
       retry_backoff: 2,
       max_buffer_size: 10_000,
-      max_buffer_bytesize: 10_000_000
+      max_buffer_bytesize: 10_000_000,
+      batched_message_limit: 1_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -21,7 +21,7 @@ module Streamy
           when :essential, :standard
             p.deliver_messages
           when :batched
-            if p.buffer_size == batched_message_size
+            if p.buffer_size >= config.producer[:batched_message_limit]
               logger.info "Delivering #{p.buffer_size} batched events now"
               p.deliver_messages
             end
@@ -70,10 +70,6 @@ module Streamy
 
         def logger
           ::Streamy.logger
-        end
-
-        def batched_message_size
-          Streamy.configuration.producer_batched_message_limit
         end
     end
   end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -118,7 +118,8 @@ module Streamy
         max_retries: 30,
         retry_backoff: 2,
         max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000
+        max_buffer_bytesize: 10_000_000,
+        batched_message_limit: 1_000
       ).returns(sync_producer)
 
       example_delivery(:essential)
@@ -132,7 +133,8 @@ module Streamy
         max_retries: 30,
         retry_backoff: 2,
         max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000
+        max_buffer_bytesize: 10_000_000,
+        batched_message_limit: 1_000
       ).returns(async_producer)
 
       example_delivery(:standard)
@@ -148,7 +150,8 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1
+        max_buffer_bytesize: 1,
+        batched_message_limit: 1
       }
 
       setup
@@ -161,7 +164,8 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1
+        max_buffer_bytesize: 1,
+        batched_message_limit: 1
       ).returns(sync_producer)
 
       example_delivery(:essential)
@@ -175,7 +179,8 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1
+        max_buffer_bytesize: 1,
+        batched_message_limit: 1
       ).returns(async_producer)
 
       example_delivery(:standard)
@@ -191,7 +196,8 @@ module Streamy
         max_retries: 2,
         retry_backoff: 2,
         max_buffer_size: 2,
-        max_buffer_bytesize: 2
+        max_buffer_bytesize: 2,
+        batched_message_limit: 2
       }
 
       client_config = {


### PR DESCRIPTION
This PR updates the config for `batched_message_limit` to be part of the kafka config, rather than `Streamy` config. It also updates the check for batched_messages against the current producers' buffer size to be `>=` 