### PR TITLE
Update config for batched message sending implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,16 +194,9 @@ You can choose a priority for your events. This is done by overriding the `prior
 * `:low` - The event will be sent to Kafka by a background thread, events are buffered until `delivery_threshold` messages are waiting or until `delivery_interval` seconds have passed since the last delivery. Calling publish on a low priority event is non blocking, and no errors should be thrown, unless the buffer is full.
 * `:standard` (default) - The event will be sent to Kafka by a background thread, but the thread is signaled to send any buffered events as soon as possible. The call to publish is non blocking, and should not throw errors, unless the buffer is full.
 * `:essential` - The event will be sent to Kafka immediately. The call to publish is blocking, and may throw errors.
-* `:batched` - The event will be queued to send to Kafka using a synchronous producer, but no events are sent until `batched_message_limit` is reached or the synchronous producer in the specific thread has `deliver_messages` called by another service. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
+* `:batched` - The event will be queued to send to Kafka using a synchronous producer, but no events are sent until `batched_message_limit` is reached (which is set to `max_buffer_size - 1`), or the synchronous producer in the specific thread has `deliver_messages` called by another service. This allows efficient event batching, when creating many events, e.g. in batch jobs. When a batch of events is being delivered the call to publish will block, and may throw errors.
 
-This can be set in the config for Streamy. (The default is `1000` messages in a batch). Be aware you should set this below the default `max_buffer_size` of `10_000`, as you will get `Kafka::BufferOverflow` errors and you would not be able to send batched messages. It can be set in the Streamy initializer in your host application as below.
-
-```ruby
-  require "streamy/message_buses/kafka_message_bus"
-  Streamy.message_bus = Streamy::MessageBuses::KafkaMessageBus.new(
-    batched_message_limit: 1000
-  )
-```
+Please read the `ruby-kafka` notes here on [buffering and error handling](https://github.com/zendesk/ruby-kafka#buffering-and-error-handling)
 
 ### Shutdown
 

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -6,8 +6,7 @@ module Streamy
       max_retries: 30,
       retry_backoff: 2,
       max_buffer_size: 10_000,
-      max_buffer_bytesize: 10_000_000,
-      batched_message_limit: 1_000
+      max_buffer_bytesize: 10_000_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -20,7 +20,7 @@ module Streamy
           when :essential, :standard
             p.deliver_messages
           when :batched
-            if p.buffer_size >= config.producer[:batched_message_limit]
+            if p.buffer_size >= batched_message_limit
               logger.info "Delivering #{p.buffer_size} batched events now"
               p.deliver_messages
             end
@@ -69,6 +69,10 @@ module Streamy
 
         def logger
           ::Streamy.logger
+        end
+
+        def batched_message_limit
+          config.producer[:max_buffer_size] - 1
         end
     end
   end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -76,15 +76,15 @@ module Streamy
     end
 
     def test_batched_priority_deliver # rubocop:disable Metrics/AbcSize
-      sync_producer.stubs(:buffer_size).returns(998)
+      sync_producer.stubs(:buffer_size).returns(9997)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(999)
+      sync_producer.stubs(:buffer_size).returns(9998)
       sync_producer.expects(:produce).with(*expected_event)
       example_delivery(:batched)
 
-      sync_producer.stubs(:buffer_size).returns(1000)
+      sync_producer.stubs(:buffer_size).returns(9999)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
@@ -102,7 +102,7 @@ module Streamy
       async_producer.expects(:deliver_messages)
       example_delivery(:standard)
 
-      sync_producer.stubs(:buffer_size).returns(1000)
+      sync_producer.stubs(:buffer_size).returns(10000)
       sync_producer.expects(:produce).with(*expected_event)
       sync_producer.expects(:deliver_messages)
       example_delivery(:batched)
@@ -117,8 +117,7 @@ module Streamy
         max_retries: 30,
         retry_backoff: 2,
         max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000,
-        batched_message_limit: 1_000
+        max_buffer_bytesize: 10_000_000
       ).returns(sync_producer)
 
       example_delivery(:essential)
@@ -132,8 +131,7 @@ module Streamy
         max_retries: 30,
         retry_backoff: 2,
         max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000,
-        batched_message_limit: 1_000
+        max_buffer_bytesize: 10_000_000
       ).returns(async_producer)
 
       example_delivery(:standard)
@@ -149,8 +147,7 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1,
-        batched_message_limit: 1
+        max_buffer_bytesize: 1
       }
 
       setup
@@ -163,8 +160,7 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1,
-        batched_message_limit: 1
+        max_buffer_bytesize: 1
       ).returns(sync_producer)
 
       example_delivery(:essential)
@@ -178,8 +174,7 @@ module Streamy
         max_retries: 1,
         retry_backoff: 1,
         max_buffer_size: 1,
-        max_buffer_bytesize: 1,
-        batched_message_limit: 1
+        max_buffer_bytesize: 1
       ).returns(async_producer)
 
       example_delivery(:standard)
@@ -195,8 +190,7 @@ module Streamy
         max_retries: 2,
         retry_backoff: 2,
         max_buffer_size: 2,
-        max_buffer_bytesize: 2,
-        batched_message_limit: 2
+        max_buffer_bytesize: 2
       }
 
       client_config = {


### PR DESCRIPTION
This PR updates the implementation of batch message limit, to send the batch when the buffer reaches `[:max_buffer_size] -1 `.

This implementation is better as users of Streamy will always have the correct limit for batch sending, rather than setting to individual config attributes that they could get wrong.