### PR TITLE
Expose the original error class

### DIFF
--- a/lib/streamy/errors/publication_failed_error.rb
+++ b/lib/streamy/errors/publication_failed_error.rb
@@ -1,10 +1,11 @@
 module Streamy
   class PublicationFailedError < StandardError
-    attr_reader :event_params
+    attr_reader :event_params, :error_class
 
     def initialize(original_error, event)
       @event_params = event.to_params
-      super "Failed publishing event: #{event_params} \n#{original_error.class} - #{original_error.message}"
+      @error_class = original_error.class
+      super "Failed publishing event: #{event_params} \n#{error_class} - #{original_error.message}"
     end
   end
 end


### PR DESCRIPTION
I am looking at adding some additional metrics around publication
failed errors as part of https://github.com/cookpad/global-sre/issues/618

I want to label the metrics using the class of the original error
to provide a little more detail in my instrumentation code.