### PR TITLE
Fix flaky avro serialization tests

### DIFF
--- a/lib/streamy/serializers/avro_serializer.rb
+++ b/lib/streamy/serializers/avro_serializer.rb
@@ -15,6 +15,10 @@ module Streamy
         )
       end
 
+      def self.clear_messaging_cache
+        @_messaging = connect_avro
+      end
+
       def self.encode(payload)
         messaging.encode(payload.deep_stringify_keys, schema_name: payload[:type])
       end

--- a/test/avro_deserializer_test.rb
+++ b/test/avro_deserializer_test.rb
@@ -7,6 +7,7 @@ module Streamy
     def setup
       Streamy.configuration.avro_schema_registry_url = "http://registry.example.com"
       Streamy.configuration.avro_schemas_path = "test/fixtures/schemas"
+      Serializers::AvroSerializer.clear_messaging_cache
       FakeConfluentSchemaRegistryServer.clear
       stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
     end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -7,6 +7,7 @@ module Streamy
     def setup
       Streamy.configuration.avro_schema_registry_url = "http://registry.example.com"
       Streamy.configuration.avro_schemas_path = "test/fixtures/schemas"
+      Serializers::AvroSerializer.clear_messaging_cache
       FakeConfluentSchemaRegistryServer.clear
       stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
     end


### PR DESCRIPTION
This is the fix for the flaky spec discovered during development of #100 

Here is the summary of the situation:

- In `AvroSerializer`, we are [memoizing the instance of `AvroTurf::Messaging`](https://github.com/cookpad/streamy/blob/34531cc4ea0a070e6d59985e15c4c93032c54e60/lib/streamy/serializers/avro_serializer.rb#L7) in a class instance variable which means that the same instance would be used for any call to `AvroSerializer::encode` test suite during a run of `rake test`. 
- `AvroTurf::Messaging` [uses an in memory cache](https://github.com/dasch/avro_turf/blob/fbcfba68f5136ea4a7fc7f88c6d09dc74ad539cb/lib/avro_turf/cached_confluent_schema_registry.rb#L32) of Avro schemas to ids and would skip registering with the server if it already had the schema in memory. 
- `FakeConfluentSchemaRegistryServer.clear` is called in the setup of our tests. 
- `FakeConfluentSchemaRegistryServer` also maintains the schemas it has seen in the (*so called*) "constant" `SCHEMAS`
- `FakeConfluentSchemaRegistryServer` only adds things to `SCHEMAS` in calls to [post "/subjects/:subject/versions"](https://github.com/dasch/avro_turf/blob/fbcfba68f5136ea4a7fc7f88c6d09dc74ad539cb/lib/avro_turf/test/fake_confluent_schema_registry_server.rb#L47) so this endpoint has to be called before any schema will be available to be fetched from `get "/schemas/ids/:schema_id"`
- If the other test that calls `AvroSerializer::encode` was run before `AvroDeserializerTest#test_deserialized_message` in the current run of tests, the class level memoized instance of `AvroTurf::Messaging` would already have a cached schema for `test_event`. So, the schema wouldn't get registered with `FakeConfluentSchemaRegistryServer`, and when the call to `Deserializers::AvroDeserializer.new.call(message)` would [eventually try to fetch the schema](https://github.com/dasch/avro_turf/blob/fbcfba68f5136ea4a7fc7f88c6d09dc74ad539cb/lib/avro_turf/messaging.rb#L160) from the registry server (which had been cleared, mind), the schema wouldn't be present in `FakeConfluentSchemaRegistryServer::SCHEMAS` and the whole house of cards comes tumbling down 🃏 

After discussing some options for how to solve this with @dannyd4315, we came to the conclusion that the most practical approach was to add a method to `AvroSerializer` that would clear the in-memory cache used by `AvroTurf::Messaging` by instantiating and memoizing a new instance of that class.

This does add a method that is only called by the tests but it allows us to break the cache and ensure that our tests run in isolation and with a clean slate without having to modify other libraries. 
