### PR TITLE
Adding Avro namespace schema support

### DIFF
--- a/lib/streamy/avro_event.rb
+++ b/lib/streamy/avro_event.rb
@@ -3,7 +3,11 @@ module Streamy
     require "streamy/serializers/avro_serializer"
 
     def encoded_payload
-      Serializers::AvroSerializer.encode(payload)
+      Serializers::AvroSerializer.encode(payload, schema_namespace: schema_namespace)
     end
+
+
+    private
+      def schema_namespace; end
   end
 end

--- a/lib/streamy/serializers/avro_serializer.rb
+++ b/lib/streamy/serializers/avro_serializer.rb
@@ -19,8 +19,8 @@ module Streamy
         @_messaging = connect_avro
       end
 
-      def self.encode(payload)
-        messaging.encode(payload.deep_stringify_keys, schema_name: payload[:type])
+      def self.encode(payload, schema_namespace: nil)
+        messaging.encode(payload.deep_stringify_keys, schema_name: payload[:type], namespace: schema_namespace)
       end
     end
   end

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -52,6 +52,12 @@ module Streamy
       def event_time; end
     end
 
+    class TestEventWithSchemaNamespace < TestEvent
+      def schema_namespace
+        "my_namespace"
+      end
+    end
+
     def test_publish
       SecureRandom.stubs(:uuid).returns("IAMUUID")
 
@@ -62,6 +68,19 @@ module Streamy
         topic: :bacon,
         priority: :standard,
         payload: "\u0000\u0000\u0000\u0000\u0000\u0014test_event\u0002\fnowish\u0002\btrue\u0002\nfalse"
+      )
+    end
+
+    def test_publish_event_with_schema_namespace
+      SecureRandom.stubs(:uuid).returns("IAMUUID")
+
+      TestEventWithSchemaNamespace.publish
+
+      assert_delivered_message(
+        key: "IAMUUID",
+        topic: :bacon,
+        priority: :standard,
+        payload: "\u0000\u0000\u0000\u0000\u0000@test_event_with_schema_namespace\u0002\fnowish\u0002\btrue\u0002\nfalse"
       )
     end
 

--- a/test/fixtures/schemas/my_namespace/test_event_with_schema_namespace.avsc
+++ b/test/fixtures/schemas/my_namespace/test_event_with_schema_namespace.avsc
@@ -1,0 +1,36 @@
+{
+   "type": "record",
+   "name": "test_event_with_schema_namespace",
+   "namespace": "my_namespace",
+   "fields": [
+     {
+       "name": "type",
+       "type": "string"
+     },
+     {
+       "name": "event_time",
+       "type": ["null", "string"],
+       "default": null
+     },
+     {
+       "name": "body",
+       "type": {
+         "type": "record",
+         "name": "body",
+         "namespace": "test_event",
+         "fields": [
+           {
+             "name": "smoked",
+             "type": ["null", "string"],
+             "default": null
+           },
+           {
+             "name": "streaky",
+             "type": ["null", "string"],
+             "default": null
+           }
+         ]
+       }
+     }
+   ]
+}


### PR DESCRIPTION
Adding support for namespaced schemas this is the result of https://github.com/cookpad/global-web/pull/21096. This will basically allow us to organize and re-use our schemas.

```ruby
store = AvroTurf::SchemaStore.new(path: 'my/schemas')
store.load_schemas!

# Accessing 'person' is correct and works fine.
person = store.find('recipes', 'ingredient') # my/schemas/recipes/ingredient.avsc exists
```

https://github.com/cookpad/developer-productivity-squad/issues/203