### PR TITLE
Update CI badge to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Streamy
 
-[![Build Status](https://circleci.com/gh/cookpad/streamy/tree/master.svg?style=svg)](https://circleci.com/gh/cookpad/streamy/tree/master)
+[![Build Status](https://circleci.com/gh/cookpad/streamy/tree/main.svg?style=svg)](https://circleci.com/gh/cookpad/streamy/tree/main)
 
 ## Installation
 


### PR DESCRIPTION
This PR updates the CI badge to point to main branch as we update default branch name to `main`.