### PR TITLE
add ability to use streamy with karafka v1.4+

### DIFF
--- a/lib/streamy/deserializers/avro_deserializer.rb
+++ b/lib/streamy/deserializers/avro_deserializer.rb
@@ -3,20 +3,17 @@ module Streamy
     class AvroDeserializer
       require "avro_turf/messaging"
 
-      DEFAULT_PAYLOAD_FETCHER = ->(params) { params["payload"] }
-
-      def initialize(&payload_fetcher)
+      def initialize
         @avro = AvroTurf::Messaging.new(registry_url: Streamy.configuration.avro_schema_registry_url)
-        @payload_fetcher = payload_fetcher || DEFAULT_PAYLOAD_FETCHER
       end
 
       def call(params)
-        avro.decode(payload_fetcher.call(params))
+        avro.decode(params.raw_payload)
       end
 
       private
 
-        attr_reader :avro, :payload_fetcher
+        attr_reader :avro
     end
   end
 end

--- a/lib/streamy/deserializers/avro_deserializer.rb
+++ b/lib/streamy/deserializers/avro_deserializer.rb
@@ -3,17 +3,20 @@ module Streamy
     class AvroDeserializer
       require "avro_turf/messaging"
 
-      def initialize
+      DEFAULT_PAYLOAD_FETCHER = ->(params) { params["payload"] }
+
+      def initialize(&payload_fetcher)
         @avro = AvroTurf::Messaging.new(registry_url: Streamy.configuration.avro_schema_registry_url)
+        @payload_fetcher = payload_fetcher || DEFAULT_PAYLOAD_FETCHER
       end
 
       def call(params)
-        avro.decode(params["payload"])
+        avro.decode(payload_fetcher.call(params))
       end
 
       private
 
-        attr_reader :avro
+        attr_reader :avro, :payload_fetcher
     end
   end
 end

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "pry", "~> 0.11"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "ruby-kafka", "~> 1.0.0"
   spec.add_development_dependency "sinatra"
 
   spec.add_dependency "activesupport", ">= 5.2"

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -39,10 +39,11 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "pry", "~> 0.11"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "ruby-kafka", "~> 0.6"
+  spec.add_development_dependency "ruby-kafka", "~> 1.0.0"
   spec.add_development_dependency "sinatra"
 
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "avro_turf", "~> 1.3.0"
+  spec.add_dependency "karafka", "~> 1.4.0"
   spec.add_dependency "webmock", "~> 3.3"
 end

--- a/test/avro_deserializer_test.rb
+++ b/test/avro_deserializer_test.rb
@@ -27,11 +27,30 @@ module Streamy
       def event_time
         "nowish"
       end
+
+      alias_method :raw_payload, :encoded_payload
     end
 
     def test_deserialized_message
       message = TestEvent.new.to_message.stringify_keys
       result = Deserializers::AvroDeserializer.new.call(message)
+
+      assert_equal(
+        {
+          "type" => "test_event",
+          "event_time" => "nowish",
+          "body" => {
+            "smoked" => "true",
+            "streaky" => "false"
+          }
+        }, result
+      )
+    end
+
+    def test_deserialized_message_with_custom_payload_source
+      message = TestEvent.new
+      deserializer = Deserializers::AvroDeserializer.new { |message| message.raw_payload }
+      result = deserializer.call(message)
 
       assert_equal(
         {

--- a/test/avro_deserializer_test.rb
+++ b/test/avro_deserializer_test.rb
@@ -29,7 +29,7 @@ module Streamy
       end
 
       def to_encoded_params
-        OpenStruct.new(to_params.merge(raw_payload: encoded_payload))
+        OpenStruct.new(raw_payload: encoded_payload)
       end
     end
 

--- a/test/avro_deserializer_test.rb
+++ b/test/avro_deserializer_test.rb
@@ -28,29 +28,14 @@ module Streamy
         "nowish"
       end
 
-      alias_method :raw_payload, :encoded_payload
+      def to_encoded_params
+        OpenStruct.new(to_params.merge(raw_payload: encoded_payload))
+      end
     end
 
     def test_deserialized_message
-      message = TestEvent.new.to_message.stringify_keys
+      message = TestEvent.new.to_encoded_params
       result = Deserializers::AvroDeserializer.new.call(message)
-
-      assert_equal(
-        {
-          "type" => "test_event",
-          "event_time" => "nowish",
-          "body" => {
-            "smoked" => "true",
-            "streaky" => "false"
-          }
-        }, result
-      )
-    end
-
-    def test_deserialized_message_with_custom_payload_source
-      message = TestEvent.new
-      deserializer = Deserializers::AvroDeserializer.new { |message| message.raw_payload }
-      result = deserializer.call(message)
 
       assert_equal(
         {


### PR DESCRIPTION
## What

PR changes the method to fetch the encoded payload to deserialize (in accordance with karafka interface changes).

This allows streamy to be used alongside the newest version of the karafka gem.

## Why 

#### The following changes were done in [karafka 1.4.0](https://github.com/karafka/karafka/blob/master/CHANGELOG.md#140-2020-09-05):
> - Remove params dependency on a hash in favour of PORO 
> - removes the #[] API from params  

As a result to get an encoded message we need to call `message#raw_payload` instead of `message["payload"]`, [karafka docs](https://github.com/karafka/karafka/wiki/Serialization#deserializers)

**Related to** https://github.com/cookpad/global-feeds/pull/1230

## How

~I added ability to pass a bloc to `AvroDeserializer#initializer` to define a source of the encoded payload source. As a result, when the gem is used along with a new karafka the following is needed~

~If the block is not passed to the method, the existing behaviour gets used.~

~I followed this approach because steamy gem does not have a direct dependency upon `karafka`, so introducing a breaking change seems to be a bit aggressive(🤔 🤷‍♀️).~

#### Alternative

The approach I have taken can be considered overly complex 😅. As far as I understand, updating `streamy` to match `karafka` is pretty straightforward. We only need to change one line of code from https://github.com/cookpad/streamy/blob/a228807cd894e4ddc7a067905dcf5373ead630ea/lib/streamy/deserializers/avro_deserializer.rb#L11

to

```ruby
  avro.decode(params.raw_payload)
```

As was suggested, I have followed the _alternative approach_. The following changes have been made:
- added direct dependency upon `karafka`
- called `params.raw_payload` to fetch encoded message. 