### PR TITLE
Add ruby 3 support for publish method

### DIFF
--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -12,8 +12,8 @@ module Streamy
       self.default_priority = level
     end
 
-    def self.publish(*args)
-      new(*args).publish
+    def self.publish(**args)
+      new(**args).publish
     end
 
     priority :standard

--- a/lib/streamy/event_handler.rb
+++ b/lib/streamy/event_handler.rb
@@ -2,8 +2,8 @@ require "active_support/core_ext/hash/indifferent_access"
 
 module Streamy
   class EventHandler
-    def self.run(*args)
-      new(*args).run
+    def self.run(**args)
+      new(**args).run
     end
 
     def initialize(params)

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "2.0.1".freeze
+  VERSION = "2.0.2".freeze
 end

--- a/test/event_handler_test.rb
+++ b/test/event_handler_test.rb
@@ -9,15 +9,15 @@ module Streamy
 
   class EventHandlerTest < Minitest::Test
     def test_accessing_body_as_hash
-      assert_equal "Title", DummyHandler.run(event)[:title]
+      assert_equal "Title", DummyHandler.run(**event)[:title]
     end
 
     def test_accessing_body_as_hash_with_string_key
-      assert_equal "Title", DummyHandler.run(event)["title"]
+      assert_equal "Title", DummyHandler.run(**event)["title"]
     end
 
     def test_accessing_body_as_object
-      assert_equal "Title", DummyHandler.run(event).title
+      assert_equal "Title", DummyHandler.run(**event).title
     end
 
     private

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -27,6 +27,15 @@ module Streamy
       def event_time; end
     end
 
+    class EventWithRecipe < Event
+      def initialize(recipe_id:)
+      end
+
+      def topic; end
+      def body; end
+      def event_time; end
+    end
+
     def test_helpful_error_message_on_missing_topic
       assert_runtime_error "topic must be implemented on Streamy::EventTest::EventWithoutTopic" do
         EventWithoutTopic.publish
@@ -55,6 +64,12 @@ module Streamy
       OveriddenPriority.publish
 
       assert_published_event(priority: :low)
+    end
+
+    def test_publish_kwargs
+      EventWithRecipe.publish(recipe_id: 22)
+
+      assert_published_event(priority: :standard)
     end
   end
 end


### PR DESCRIPTION
Add a new event called `RecipeWithEvent` that takes in a kwarg for the initialiser so ruby 3 kwargs can be tested for the publish method.

This regression was caught by cookpads test suite for ruby 3.