### PR TITLE
Fix dispatcher kwargs

### DIFF
--- a/lib/streamy/dispatcher.rb
+++ b/lib/streamy/dispatcher.rb
@@ -5,7 +5,7 @@ module Streamy
     end
 
     def dispatch
-      Streamy.message_bus.deliver(message_params)
+      Streamy.message_bus.deliver(**message_params)
     end
 
     private

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "2.0.2".freeze
+  VERSION = "2.0.3".freeze
 end

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DispatcherTest < Minitest::Test
+  def test_dispatcher
+    event = Streamy::EventTest::ValidEvent.new
+    assert_nil Streamy::Dispatcher.new(event).dispatch
+  end
+end


### PR DESCRIPTION
The dispatcher code inside the tests are currently mocked via the class `TestDispatcher`. 

This means the dispatcher class is never tested and the method is never invoked https://github.com/cookpad/streamy/pull/115/files#diff-a8045b788a31b9e61bd94e501d186161b1d82ce9227f23e694c5038b5da6a6dbL8

The args have been updated to kwargs and a test for dispatcher has been included.