### PR TITLE
Replace the `ruby-kafka` gem with the `waterdrop` gem

### DIFF
--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -30,7 +30,7 @@ module Streamy
   require "streamy/message_buses/message_bus"
 
   class << self
-    attr_accessor :message_bus, :logger, :dispatcher, :notifications_bus
+    attr_accessor :message_bus, :logger, :dispatcher, :notifications_bus, :notifications_bus_namespace
 
     def shutdown
       message_bus.try(:shutdown)
@@ -41,6 +41,7 @@ module Streamy
   self.logger = SimpleLogger.new
   self.dispatcher = Dispatcher
   self.notifications_bus = ::ActiveSupport::Notifications
+  self.notifications_bus_namespace = :kafka
 
   def self.configuration
     @configuration ||= Configuration.new

--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -3,6 +3,7 @@ module Streamy
   # TODO: Move into classes that use them
   require "active_support"
   require "active_support/core_ext/string"
+  require "active_support/notifications"
 
   require "streamy/version"
   require "streamy/configuration"
@@ -29,7 +30,7 @@ module Streamy
   require "streamy/message_buses/message_bus"
 
   class << self
-    attr_accessor :message_bus, :logger, :dispatcher
+    attr_accessor :message_bus, :logger, :dispatcher, :notifications_bus
 
     def shutdown
       message_bus.try(:shutdown)
@@ -39,6 +40,7 @@ module Streamy
   self.message_bus = MessageBuses::MessageBus.new
   self.logger = SimpleLogger.new
   self.dispatcher = Dispatcher
+  self.notifications_bus = ::ActiveSupport::Notifications
 
   def self.configuration
     @configuration ||= Configuration.new

--- a/lib/streamy.rb
+++ b/lib/streamy.rb
@@ -25,6 +25,8 @@ module Streamy
   require "streamy/errors/event_handler_not_found_error"
   require "streamy/errors/publication_failed_error"
   require "streamy/errors/type_not_found_error"
+  require "streamy/errors/unknown_priority_error"
+  require "streamy/errors/unknown_producer_type_error"
 
   # Message Buses
   require "streamy/message_buses/message_bus"

--- a/lib/streamy/deserializers/avro_deserializer.rb
+++ b/lib/streamy/deserializers/avro_deserializer.rb
@@ -3,17 +3,15 @@ module Streamy
     class AvroDeserializer
       require "avro_turf/messaging"
 
-      def initialize
-        @avro = AvroTurf::Messaging.new(registry_url: Streamy.configuration.avro_schema_registry_url)
-      end
-
       def call(params)
         avro.decode(params.raw_payload)
       end
 
       private
 
-        attr_reader :avro
+        def avro
+          @_avro ||= AvroTurf::Messaging.new(registry_url: Streamy.configuration.avro_schema_registry_url)
+        end
     end
   end
 end

--- a/lib/streamy/errors/unknown_priority_error.rb
+++ b/lib/streamy/errors/unknown_priority_error.rb
@@ -1,0 +1,7 @@
+module Streamy
+  class UnknownPriorityError < StandardError
+    def initialize(priority)
+      super "Unknown priority #{priority}"
+    end
+  end
+end

--- a/lib/streamy/errors/unknown_producer_type_error.rb
+++ b/lib/streamy/errors/unknown_producer_type_error.rb
@@ -1,0 +1,7 @@
+module Streamy
+  class UnknownProducerTypeError < StandardError
+    def initialize(producer_type)
+      super "Unknown producer type #{producer_type}"
+    end
+  end
+end

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -1,21 +1,22 @@
 module Streamy
   class KafkaConfiguration < SimpleDelegator
     DEFAULT_SYNC_CONFIG = {
-      "request.required.acks": -1, # required_acks: -1 all replicas
-      "request.timeout.ms": 5_000, # ack_timeout: 5
-      "message.send.max.retries": 30, # max_retries: 30
-      "retry.backoff.ms": 2_000, # retry_backoff: 2
-      "queue.buffering.max.messages": 10_000, # max_buffer_size : 10_000
-      "queue.buffering.max.kbytes": 10_000 # max_buffer_bytesize: 10_000_000
+      "request.required.acks": -1,
+      "request.timeout.ms": 5_000,
+      "message.send.max.retries": 30,
+      "retry.backoff.ms": 2_000,
+      "queue.buffering.max.messages": 10_000,
+      "queue.buffering.max.kbytes": 10_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {
-      "batch.num.messages": 100, # delivery_threshold: 100
-      "queue.buffering.max.ms": 10_000 # delivery_interval: 10
+      "queue.buffering.max.messages": 5_000,
+      "batch.num.messages": 100,
+      "queue.buffering.max.ms": 10_000
     }.freeze
 
     def async
-      sync.with_defaults(DEFAULT_ASYNC_CONFIG)
+      with_defaults(DEFAULT_ASYNC_CONFIG).with_defaults(DEFAULT_SYNC_CONFIG)
     end
 
     def sync

--- a/lib/streamy/kafka_configuration.rb
+++ b/lib/streamy/kafka_configuration.rb
@@ -1,34 +1,25 @@
 module Streamy
   class KafkaConfiguration < SimpleDelegator
-    DEFAULT_PRODUCER_CONFIG = {
-      required_acks: -1, # all replicas
-      ack_timeout: 5,
-      max_retries: 30,
-      retry_backoff: 2,
-      max_buffer_size: 10_000,
-      max_buffer_bytesize: 10_000_000
+    DEFAULT_SYNC_CONFIG = {
+      "request.required.acks": -1, # required_acks: -1 all replicas
+      "request.timeout.ms": 5_000, # ack_timeout: 5
+      "message.send.max.retries": 30, # max_retries: 30
+      "retry.backoff.ms": 2_000, # retry_backoff: 2
+      "queue.buffering.max.messages": 10_000, # max_buffer_size : 10_000
+      "queue.buffering.max.kbytes": 10_000 # max_buffer_bytesize: 10_000_000
     }.freeze
 
     DEFAULT_ASYNC_CONFIG = {
-      max_queue_size: 5_000,
-      delivery_threshold: 100,
-      delivery_interval: 10
-    }.freeze
-
-    DEFAULT_KAFKA_CONFIG = {
-      logger: Streamy.logger
+      "batch.num.messages": 100, # delivery_threshold: 100
+      "queue.buffering.max.ms": 10_000 # delivery_interval: 10
     }.freeze
 
     def async
-      slice(*DEFAULT_ASYNC_CONFIG.keys).with_defaults(DEFAULT_ASYNC_CONFIG).merge(producer)
+      sync.with_defaults(DEFAULT_ASYNC_CONFIG)
     end
 
-    def producer
-      slice(*DEFAULT_PRODUCER_CONFIG.keys).with_defaults(DEFAULT_PRODUCER_CONFIG)
-    end
-
-    def kafka
-      except(*async.keys).with_defaults(DEFAULT_KAFKA_CONFIG)
+    def sync
+      with_defaults(DEFAULT_SYNC_CONFIG)
     end
   end
 end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -1,7 +1,6 @@
 require "streamy/kafka_configuration"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/json"
-require "active_support/notifications"
 
 module Streamy
   module MessageBuses
@@ -67,7 +66,7 @@ module Streamy
         def build_producer(kafka_config)
           WaterDrop::Producer.new do |producer_config|
             producer_config.logger = Streamy.logger
-            producer_config.monitor = WaterDrop::Instrumentation::Monitor.new(::ActiveSupport::Notifications)
+            producer_config.monitor = WaterDrop::Instrumentation::Monitor.new(Streamy.notifications_bus)
             producer_config.kafka = kafka_config
           end
         end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -66,7 +66,10 @@ module Streamy
         def build_producer(kafka_config)
           WaterDrop::Producer.new do |producer_config|
             producer_config.logger = Streamy.logger
-            producer_config.monitor = WaterDrop::Instrumentation::Monitor.new(Streamy.notifications_bus)
+            producer_config.monitor = WaterDrop::Instrumentation::Monitor.new(
+              Streamy.notifications_bus,
+              Streamy.notifications_bus_namespace
+            )
             producer_config.kafka = kafka_config
           end
         end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -17,7 +17,7 @@ module Streamy
           when :standard, :low
             p.produce_async(payload: payload, key: key, topic: topic.to_s)
           else
-            fail "Unknown priority"
+            raise ::Streamy::UnknownPriorityError.new(priority)
           end
         end
       end
@@ -38,7 +38,7 @@ module Streamy
           when :standard, :low
             async_producer
           else
-            fail "Unknown priority"
+            raise UnknownPriorityError.new(priority)
           end
         end
 
@@ -65,7 +65,7 @@ module Streamy
 
         def build_producer(kafka_config)
           WaterDrop::Producer.new do |producer_config|
-            producer_config.logger = Streamy.logger
+            producer_config.logger = logger
             producer_config.monitor = WaterDrop::Instrumentation::Monitor.new(
               Streamy.notifications_bus,
               Streamy.notifications_bus_namespace
@@ -81,7 +81,7 @@ module Streamy
           when :async
             config.async
           else
-            fail "Unknown producer type"
+            raise UnknownProducerTypeError.new(producer_type)
           end
         end
 

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "2.0.3".freeze
+  VERSION = "3.0.0".freeze
 end

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "avro_turf", "~> 1.3.0"
-  spec.add_dependency 'waterdrop', '>= 2.4.10', '< 3.0.0'
+  spec.add_dependency "waterdrop", ">= 2.4.10", "< 3.0.0"
   spec.add_dependency "webmock", "~> 3.3"
 end

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "avro_turf", "~> 1.3.0"
-  spec.add_dependency "karafka", "~> 1.4.0"
+  spec.add_dependency "karafka", "~> 2.0"
   spec.add_dependency "webmock", "~> 3.3"
 end

--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
 
   spec.add_dependency "activesupport", ">= 5.2"
   spec.add_dependency "avro_turf", "~> 1.3.0"
-  spec.add_dependency "karafka", "~> 2.0"
+  spec.add_dependency 'waterdrop', '>= 2.4.10', '< 3.0.0'
   spec.add_dependency "webmock", "~> 3.3"
 end

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -1,8 +1,9 @@
 require "test_helper"
+require_relative "./event_test"
 
 class DispatcherTest < Minitest::Test
   def test_dispatcher
-    event = Streamy::EventTest::ValidEvent.new
-    assert_nil Streamy::Dispatcher.new(event).dispatch
+    event = ::Streamy::EventTest::ValidEvent.new
+    assert_nil ::Streamy::Dispatcher.new(event).dispatch
   end
 end

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "karafka"
+require "waterdrop"
 require "streamy/message_buses/kafka_message_bus"
 
 module Streamy
@@ -99,7 +99,7 @@ module Streamy
         "request.timeout.ms": 5000,
         "message.send.max.retries": 30,
         "retry.backoff.ms": 2000,
-        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.messages": 5_000,
         "queue.buffering.max.kbytes": 10_000,
         "queue.buffering.max.ms": 10_000,
         "batch.num.messages": 100
@@ -133,7 +133,7 @@ module Streamy
         "request.timeout.ms": 2000,
         "message.send.max.retries": 30,
         "retry.backoff.ms": 2000,
-        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.messages": 5000,
         "queue.buffering.max.kbytes": 10_000,
         "queue.buffering.max.ms": 10_000,
         "batch.num.messages": 100,
@@ -143,11 +143,17 @@ module Streamy
       example_delivery(:standard)
     end
 
-    def test_shutdown
+    def test_sync_producer_shutdown
       example_delivery(:essential)
-      example_delivery(:standard)
 
       producer.expects(:shutdown)
+
+      bus.shutdown
+    end
+
+    def test_async_producer_shutdown
+      example_delivery(:standard)
+
       producer.expects(:shutdown)
 
       bus.shutdown

--- a/test/message_buses/kafka_message_bus_test.rb
+++ b/test/message_buses/kafka_message_bus_test.rb
@@ -1,27 +1,32 @@
 require "test_helper"
+require "karafka"
 require "streamy/message_buses/kafka_message_bus"
 
 module Streamy
   class KafkaMessageBusTest < Minitest::Test
-    attr_reader :bus, :kafka, :async_producer, :sync_producer
+    attr_reader :bus
 
-    def setup # rubocop:disable Metrics/AbcSize
-      @kafka = mock("kafka")
-      @async_producer = mock("async_producer")
-      kafka.stubs(:async_producer).returns(async_producer)
-      @sync_producer = mock("sync_producer")
-      kafka.stubs(:producer).returns(sync_producer)
-      Kafka.stubs(:new).returns(kafka)
+    def setup
       @bus = MessageBuses::KafkaMessageBus.new(@config || {})
+      WaterDrop::Producer.any_instance.stubs(:produce_sync)
+      WaterDrop::Producer.any_instance.stubs(:produce_async)
     end
 
     def teardown
       Thread.current[:streamy_kafka_sync_producer] = nil
     end
 
+    def producer
+      WaterDrop::Producer.any_instance
+    end
+
+    def build_producer
+      WaterDrop::Producer.new
+    end
+
     def example_delivery(priority)
       bus.deliver(
-        payload: payload,
+        payload: payload.to_s,
         key: "prk-sg-001",
         topic: "charcuterie",
         priority: priority
@@ -38,184 +43,112 @@ module Streamy
 
     def expected_event
       [
-        {
+        payload: {
           type: "sausage",
           body: {
             meat: "pork",
             herbs: "sage"
           },
           event_time: "2018"
-        },
+        }.to_s,
         key: "prk-sg-001",
         topic: "charcuterie"
       ]
     end
 
-    def stub_producers
-      sync_producer.stubs(:produce)
-      sync_producer.stubs(:deliver_messages)
-      async_producer.stubs(:produce)
-      async_producer.stubs(:deliver_messages)
-    end
-
     def test_standard_priority_deliver
-      async_producer.expects(:produce).with(*expected_event)
-      async_producer.expects(:deliver_messages)
+      producer.expects(:produce_async).with(*expected_event)
       example_delivery(:standard)
     end
 
     def test_low_priority_deliver
-      async_producer.expects(:produce).with(*expected_event)
+      producer.expects(:produce_async).with(*expected_event)
       example_delivery(:low)
     end
 
     def test_essential_priority_deliver
-      sync_producer.expects(:produce).with(*expected_event)
-      sync_producer.expects(:deliver_messages)
+      producer.expects(:produce_sync).with(*expected_event)
       example_delivery(:essential)
     end
 
-    def test_batched_priority_deliver # rubocop:disable Metrics/AbcSize
-      sync_producer.stubs(:buffer_size).returns(9997)
-      sync_producer.expects(:produce).with(*expected_event)
-      example_delivery(:batched)
-
-      sync_producer.stubs(:buffer_size).returns(9998)
-      sync_producer.expects(:produce).with(*expected_event)
-      example_delivery(:batched)
-
-      sync_producer.stubs(:buffer_size).returns(9999)
-      sync_producer.expects(:produce).with(*expected_event)
-      sync_producer.expects(:deliver_messages)
-      example_delivery(:batched)
-    end
-
-    def test_all_priority_delivery # rubocop:disable Metrics/AbcSize
-      sync_producer.expects(:produce).with(*expected_event)
-      sync_producer.expects(:deliver_messages)
+    def test_all_priority_delivery
+      producer.expects(:produce_sync).with(*expected_event)
       example_delivery(:essential)
 
-      async_producer.expects(:produce).with(*expected_event)
+      producer.expects(:produce_async).with(*expected_event)
       example_delivery(:low)
 
-      async_producer.expects(:produce).with(*expected_event)
-      async_producer.expects(:deliver_messages)
+      producer.expects(:produce_async).with(*expected_event)
       example_delivery(:standard)
-
-      sync_producer.stubs(:buffer_size).returns(10000)
-      sync_producer.expects(:produce).with(*expected_event)
-      sync_producer.expects(:deliver_messages)
-      example_delivery(:batched)
     end
 
     def test_config_defaults
-      stub_producers
-
-      kafka.expects(:producer).with(
-        required_acks: -1,
-        ack_timeout: 5,
-        max_retries: 30,
-        retry_backoff: 2,
-        max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000
-      ).returns(sync_producer)
+      bus.expects(:build_producer).with(
+        "request.required.acks": -1,
+        "request.timeout.ms": 5000,
+        "message.send.max.retries": 30,
+        "retry.backoff.ms": 2000,
+        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.kbytes": 10_000
+      ).returns(build_producer)
 
       example_delivery(:essential)
 
-      kafka.expects(:async_producer).with(
-        max_queue_size: 5_000,
-        delivery_threshold: 100,
-        delivery_interval: 10,
-        required_acks: -1,
-        ack_timeout: 5,
-        max_retries: 30,
-        retry_backoff: 2,
-        max_buffer_size: 10_000,
-        max_buffer_bytesize: 10_000_000
-      ).returns(async_producer)
+      bus.expects(:build_producer).with(
+        "request.required.acks": -1,
+        "request.timeout.ms": 5000,
+        "message.send.max.retries": 30,
+        "retry.backoff.ms": 2000,
+        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.kbytes": 10_000,
+        "queue.buffering.max.ms": 10_000,
+        "batch.num.messages": 100
+      ).returns(build_producer)
 
       example_delivery(:standard)
     end
 
-    def test_config_overides
+    def test_config_overrides
       @config = {
-        max_queue_size: 1,
-        delivery_threshold: 1,
-        delivery_interval: 1,
-        required_acks: 1,
-        ack_timeout: 1,
-        max_retries: 1,
-        retry_backoff: 1,
-        max_buffer_size: 1,
-        max_buffer_bytesize: 1
+        "request.timeout.ms": 2000,
+        "socket.keepalive.enable": true
       }
 
       setup
 
-      stub_producers
-
-      kafka.expects(:producer).with(
-        required_acks: 1,
-        ack_timeout: 1,
-        max_retries: 1,
-        retry_backoff: 1,
-        max_buffer_size: 1,
-        max_buffer_bytesize: 1
-      ).returns(sync_producer)
+      bus.expects(:build_producer).with(
+        "request.required.acks": -1,
+        "request.timeout.ms": 2000,
+        "message.send.max.retries": 30,
+        "retry.backoff.ms": 2000,
+        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.kbytes": 10_000,
+        "socket.keepalive.enable": true
+      ).returns(build_producer)
 
       example_delivery(:essential)
 
-      kafka.expects(:async_producer).with(
-        max_queue_size: 1,
-        delivery_threshold: 1,
-        delivery_interval: 1,
-        required_acks: 1,
-        ack_timeout: 1,
-        max_retries: 1,
-        retry_backoff: 1,
-        max_buffer_size: 1,
-        max_buffer_bytesize: 1
-      ).returns(async_producer)
+      bus.expects(:build_producer).with(
+        "request.required.acks": -1,
+        "request.timeout.ms": 2000,
+        "message.send.max.retries": 30,
+        "retry.backoff.ms": 2000,
+        "queue.buffering.max.messages": 10_000,
+        "queue.buffering.max.kbytes": 10_000,
+        "queue.buffering.max.ms": 10_000,
+        "batch.num.messages": 100,
+        "socket.keepalive.enable": true
+      ).returns(build_producer)
 
       example_delivery(:standard)
-    end
-
-    def test_client_config
-      producer_config = {
-        max_queue_size: 2,
-        delivery_threshold: 2,
-        delivery_interval: 2,
-        required_acks: 2,
-        ack_timeout: 2,
-        max_retries: 2,
-        retry_backoff: 2,
-        max_buffer_size: 2,
-        max_buffer_bytesize: 2
-      }
-
-      client_config = {
-        client_id: "test",
-        seed_brokers: "test-broker:9092",
-        sasl_plain_username: "tester",
-        sasl_plain_password: "blue",
-        ssl_ca_certs_from_system: true,
-        logger: Streamy.logger
-      }
-
-      config = client_config.merge(producer_config)
-
-      Kafka.expects(:new).with(client_config)
-      MessageBuses::KafkaMessageBus.new(config)
     end
 
     def test_shutdown
-      stub_producers
-
       example_delivery(:essential)
       example_delivery(:standard)
 
-      async_producer.expects(:shutdown)
-      sync_producer.expects(:shutdown)
+      producer.expects(:shutdown)
+      producer.expects(:shutdown)
 
       bus.shutdown
     end


### PR DESCRIPTION
## What

The goal of this PR is to replace the `ruby-kafka` gem with the `waterdrop` gem as the dependency for karafka, as `ruby-kafka` is being deprecated.

## Why

Both [Ruby-Kafka](https://github.com/zendesk/ruby-kafka#deprecation-notice) and Karafka v1.4  are deprecated

## How

1. The update involves _replacing the Kafka gem dependency with the Waterdrop gem_. While Karafka is a Kafka processing framework, Waterdrop is a gem for producing messages to Kafka. So it seems to me that Waterdrop is the right dependency here, especially since we're using Waterdrop directly.
2. I decided to stick with the existing approach of creating new producer instances when an event is published synchronously. Also, new waterdrop clients are safer in terms of potential workload (one producer should be enough for up to 5k msq/s per single ruby process, waterdrop is fully thread-safe)
4. Since the producer gets configured during instance initialization, I refactored `KafkaConfiguration` to support `SYNC_CONFIG` and `ASYNC_CONFIG` only. In addition, I refactored the class to support any configuration we may want to use (instead of `slicing` allowed configs). The full list of possible options can be found [here](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md. )
5. Introduced the `monitor` config, which allows streamy events to be sent to `ActiveSupport::Notifications` instead of using the default notification bus. This is necessary to subscribe to events outside the streamy gem. This allows us to maintain the current approach for https://github.com/errm/promenade.
6. **Changed or removed kafka configs**

| Old config name | New config name |
| - | - |
| Sync Producer | - |
| `required_acks` | `request.required.acks` |
| `ack_timeout` | `request.timeout.ms` |
| `max_retries` | `message.send.max.retries` |
| `retry_backoff` | `retry.backoff.ms` |
| `max_buffer_size ` | `queue.buffering.max.messages` |
| `max_buffer_bytesize ` | `queue.buffering.max.kbytes` |
| Async Producer | - |
| `delivery_threshold` | `batch.num.messages` |
| `delivery_interval ` | `queue.buffering.max.ms` |
| `max_queue_size ` | N/A (Does not exist, no close match) |

**New config**
Waterdrop producer config:
- `monitor` = WaterDrop::Instrumentation::Monitor.new(::ActiveSupport::Notifications)
- `Streamy.logger` has been moved to producer config when we build a Waterdrop producer.

## Anything Else

1. As a temporary solution, the batched priority has been removed since it's not currently in use. In addition, we may consider creating a new gem or extending streamy with shared behavior between global-web and global-feeds.
2. The PR was tested along with `https://github.com/cookpad/global-web/pull/34666` and `https://github.com/cookpad/global-feeds/pull/1661`.
3.  It's possible to override all the configurations defined in this PR during the initialization of Streamy from outside.
, https://github.com/cookpad/global-web/blob/9f9ef0dcb40ca3a9b42e5e410af3dadfd4f6bed2/config/initializers/streamy.rb#L8