### PR TITLE
add cause to the logged error message 

### DIFF
--- a/lib/streamy/errors/publication_failed_error.rb
+++ b/lib/streamy/errors/publication_failed_error.rb
@@ -4,7 +4,10 @@ module Streamy
 
     def initialize(original_error, event)
       @event_params = event.to_params
-      super "Failed publishing event: #{event_params} \n#{original_error.class} - #{original_error.message}"
+      message = %( Failed publishing event: #{event_params}
+      #{original_error.class} - #{original_error.message}, caused by  #{original_error.try(:cause)}
+      )
+      super message
     end
   end
 end

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -1,4 +1,5 @@
 require "streamy/kafka_configuration"
+require "waterdrop"
 require "active_support/core_ext/hash/indifferent_access"
 require "active_support/json"
 

--- a/lib/streamy/version.rb
+++ b/lib/streamy/version.rb
@@ -1,3 +1,3 @@
 module Streamy
-  VERSION = "3.0.0".freeze
+  VERSION = "3.0.1".freeze
 end


### PR DESCRIPTION
### What
The PR improves the logged error message by adding a cause (if it exists)

before 

Streamy::PublicationFailedError:  Failed publishing event: {:key=>"visited_recipe_x",  #... } }
WaterDrop::Errors::ProduceError - WaterDrop::Errors::ProduceError
after 

Streamy::PublicationFailedError:  Failed publishing event: {:key=>"visited_recipe_x",  #... } }
WaterDrop::Errors::ProduceError - WaterDrop::Errors::ProduceError, caused by  Local: Queue full (queue_full)


## Anything Else

adds require "waterdrop", so it should help to fix `undefined method `shutdown'`