### PR TITLE
Support ActiveSupport >= 7.1

### DIFF
--- a/lib/streamy/simple_logger.rb
+++ b/lib/streamy/simple_logger.rb
@@ -2,7 +2,14 @@ module Streamy
   class SimpleLogger < SimpleDelegator
     def initialize(output = STDOUT)
       logger = Logger.new(output)
-      logger.formatter = ->(_, datetime, _, msg) { "#{datetime.to_s(:db)} - #{msg}\n" }
+      logger.formatter =
+        if Time.new.respond_to?(:to_fs)
+          # ActiveSupport 7.0 deprecates Time#to_s(format) and introduced Time#to_fs(format).
+          # ActiveSupport 7.1 removed Time#to_s(format).
+          ->(_, datetime, _, msg) { "#{datetime.to_fs(:db)} - #{msg}\n" }
+        else
+          ->(_, datetime, _, msg) { "#{datetime.to_s(:db)} - #{msg}\n" }
+        end
       __setobj__(logger)
     end
   end


### PR DESCRIPTION
Use Time#to_fs(format) instead of Time#to_s(format) because ActiveSupport 7.1 removed Time#to_s(format) (and it was deprecated in ActiveSupport 7.0).

- https://guides.rubyonrails.org/7_0_release_notes.html#active-support-deprecations
- https://guides.rubyonrails.org/7_1_release_notes.html#active-support-removals