### PR TITLE
Add support to deliver messages in batches

### DIFF
--- a/lib/streamy/dispatcher.rb
+++ b/lib/streamy/dispatcher.rb
@@ -8,6 +8,10 @@ module Streamy
       Streamy.message_bus.deliver(**message_params)
     end
 
+    def self.dispatch_many(events)
+      Streamy.message_bus.deliver_many(events.map(&:to_message))
+    end
+
     private
 
       attr_reader :event

--- a/lib/streamy/event.rb
+++ b/lib/streamy/event.rb
@@ -16,6 +16,10 @@ module Streamy
       new(**args).publish
     end
 
+    def self.publish_many(events)
+      Streamy.dispatcher.dispatch_many(events)
+    end
+
     priority :standard
 
     def publish

--- a/lib/streamy/message_buses/kafka_message_bus.rb
+++ b/lib/streamy/message_buses/kafka_message_bus.rb
@@ -23,6 +23,11 @@ module Streamy
         end
       end
 
+      def deliver_many(messages)
+        messages = messages.map { |message| message.except(:priority) }
+        sync_producer.produce_many_sync(messages)
+      end
+
       def shutdown
         async_producer.close if async_producer?
         sync_producers.map(&:close)

--- a/lib/streamy/message_buses/message_bus.rb
+++ b/lib/streamy/message_buses/message_bus.rb
@@ -4,6 +4,10 @@ module Streamy
       def deliver(key:, topic:, payload:, priority:)
         # NOOP: Implement delivery logic
       end
+
+      def deliver_many(messages)
+        # NOOP: Implement delivery logic
+      end
     end
   end
 end

--- a/lib/streamy/test_dispatcher.rb
+++ b/lib/streamy/test_dispatcher.rb
@@ -12,5 +12,10 @@ module Streamy
       events << event_params
       messages << message_params
     end
+
+    def self.dispatch_many(events)
+      self.events += events.map(&:to_params)
+      self.messages += events.map(&:to_message)
+    end
   end
 end


### PR DESCRIPTION
Adding support for delivering messages in batches would offer significant benefits, especially for batch jobs that involve handling multiple messages, this will substantially enhances throughput.