### PR TITLE
Relax avro_turf dependency to support a wider range of versions

### DIFF
--- a/streamy.gemspec
+++ b/streamy.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_development_dependency "sinatra"
 
   spec.add_dependency "activesupport", ">= 5.2"
-  spec.add_dependency "avro_turf", "~> 1.3.0"
+  spec.add_dependency "avro_turf", "~> 1.0"
   spec.add_dependency "waterdrop", ">= 2.4.10", "< 3.0.0"
   spec.add_dependency "webmock", "~> 3.3"
   spec.add_dependency "ostruct"


### PR DESCRIPTION
Relax the avro_turf dependency from `"~> 1.3.0"` to `"~> 1.0"` in the gemspec file to allow compatibility with all versions within the 1.x.x range, increasing flexibility for producers and consumers