### PR TITLE
Fix Sinatra 4.1 host Authorization

### DIFF
--- a/test/avro_deserializer_test.rb
+++ b/test/avro_deserializer_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "avro_turf/test/fake_confluent_schema_registry_server"
+require_relative "support/authorized_fake_confluent_schema_registry_server"
 require "webmock/minitest"
 require "ostruct"
 
@@ -9,8 +9,8 @@ module Streamy
       Streamy.configuration.avro_schema_registry_url = "http://registry.example.com"
       Streamy.configuration.avro_schemas_path = "test/fixtures/schemas"
       Serializers::AvroSerializer.clear_messaging_cache
-      FakeConfluentSchemaRegistryServer.clear
-      stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
+      stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(AuthorizedFakeConfluentSchemaRegistryServer)
+      AuthorizedFakeConfluentSchemaRegistryServer.clear
     end
 
     class TestEvent < AvroEvent

--- a/test/avro_event_test.rb
+++ b/test/avro_event_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-require "avro_turf/test/fake_confluent_schema_registry_server"
+require_relative "support/authorized_fake_confluent_schema_registry_server"
 require "webmock/minitest"
 
 module Streamy
@@ -8,8 +8,8 @@ module Streamy
       Streamy.configuration.avro_schema_registry_url = "http://registry.example.com"
       Streamy.configuration.avro_schemas_path = "test/fixtures/schemas"
       Serializers::AvroSerializer.clear_messaging_cache
-      FakeConfluentSchemaRegistryServer.clear
-      stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
+      stub_request(:any, /^#{Streamy.configuration.avro_schema_registry_url}/).to_rack(AuthorizedFakeConfluentSchemaRegistryServer)
+      AuthorizedFakeConfluentSchemaRegistryServer.clear
     end
 
     class TestEvent < AvroEvent

--- a/test/support/authorized_fake_confluent_schema_registry_server.rb
+++ b/test/support/authorized_fake_confluent_schema_registry_server.rb
@@ -1,0 +1,5 @@
+require "avro_turf/test/fake_confluent_schema_registry_server"
+
+class AuthorizedFakeConfluentSchemaRegistryServer < FakeConfluentSchemaRegistryServer
+  set :host_authorization, permitted_hosts: ['example.org', 'registry.example.com']
+end


### PR DESCRIPTION
## What 

Fix Sinatra 4.1 host Authorization

> Recent updates in sinatra introduced a new middleware to authenticate requests based on expected host headers to fix https://github.com/sinatra/sinatra/pull/2053.

## How

Following the fix implemented in https://github.com/dasch/avro_turf/pull/215